### PR TITLE
Add persistence for Tailwind version and color format preferences

### DIFF
--- a/src/components/editor/code-panel.tsx
+++ b/src/components/editor/code-panel.tsx
@@ -26,20 +26,24 @@ const CodePanel: React.FC<CodePanelProps> = ({
   themeEditorState,
   onCodePanelToggle,
 }) => {
-  const [colorFormat, setColorFormat] = useState<ColorFormat>("oklch");
-  const [tailwindVersion, setTailwindVersion] = useState<"3" | "4">("4");
   const [packageManager, setPackageManager] = useState<
     "pnpm" | "npm" | "yarn" | "bun"
   >("pnpm");
   const [registryCopied, setRegistryCopied] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const posthog = usePostHog();
+  
+  const preset = useEditorStore((state) => state.themeState.preset);
+  const colorFormat = useEditorStore((state) => state.colorFormat);
+  const tailwindVersion = useEditorStore((state) => state.tailwindVersion);
+  const setColorFormat = useEditorStore((state) => state.setColorFormat);
+  const setTailwindVersion = useEditorStore((state) => state.setTailwindVersion);
+
   const code = config.codeGenerator.generateComponentCode(
     themeEditorState,
     colorFormat,
     tailwindVersion
   );
-  const [copied, setCopied] = useState(false);
-  const posthog = usePostHog();
-  const preset = useEditorStore((state) => state.themeState.preset);
 
   const getRegistryCommand = (preset: string) => {
     const url = `https://tweakcn.com/r/themes/${preset}.json`;
@@ -156,7 +160,9 @@ const CodePanel: React.FC<CodePanelProps> = ({
           value={tailwindVersion}
           onValueChange={(value: "3" | "4") => {
             setTailwindVersion(value);
-            setColorFormat(value === "4" ? "oklch" : "hsl");
+            if (value === "4" && colorFormat === "hsl") {
+              setColorFormat("oklch");
+            }
           }}
         >
           <SelectTrigger className="w-fit focus:ring-transparent focus:border-none bg-muted/50 outline-hidden border-none gap-1">

--- a/src/store/editor-store.ts
+++ b/src/store/editor-store.ts
@@ -4,10 +4,15 @@ import { ThemeEditorState, EditorType } from "@/types/editor";
 import { isEqual } from "@ngard/tiny-isequal";
 import { defaultThemeState } from "@/config/theme";
 import { getPresetThemeStyles } from "../utils/theme-presets";
+import { ColorFormat } from "@/types";
 
 interface EditorStore {
   themeState: ThemeEditorState;
+  tailwindVersion: "3" | "4";
+  colorFormat: ColorFormat;
   setThemeState: (state: ThemeEditorState) => void;
+  setTailwindVersion: (version: "3" | "4") => void;
+  setColorFormat: (format: ColorFormat) => void;
   applyThemePreset: (preset: string) => void;
   resetToDefault: () => void;
   resetToCurrentPreset: () => void;
@@ -19,8 +24,16 @@ export const useEditorStore = create<EditorStore>()(
   persist(
     (set, get) => ({
       themeState: defaultThemeState,
+      tailwindVersion: "4",
+      colorFormat: "oklch",
       setThemeState: (state: ThemeEditorState) => {
         set({ themeState: state });
+      },
+      setTailwindVersion: (version: "3" | "4") => {
+        set({ tailwindVersion: version });
+      },
+      setColorFormat: (format: ColorFormat) => {
+        set({ colorFormat: format });
       },
       applyThemePreset: (preset: string) => {
         const themeState = get().themeState;


### PR DESCRIPTION
Fixes https://github.com/jnsahaj/tweakcn/issues/26

Added **Tailwind Version** and **Color Format** to the editor store to make them persist after reload. Previously they were reset to their default values on reload, forcing users to change it everytime in case they used a different Tailwind version or color format. These new changes ensure the saving of both the fields into our pre-existing editor store using Zustand.

## Changes
- Extended the EditorStore interface to include tailwindVersion and colorFormat properties
- Updated the code panel component to read preferences from the store instead of using local state
- Improved the version switching behavior to only change the color format when necessary

## Testing Instructions
- Start the app development server (or test it in prod :P)
- Change Tailwind version (eg v4 to v3)
- Change color format (eg oklch to rgb)
- Refresh this page, or close it.
- Reopen the page in case you closed it, and ensure the previous changes are still preserved.
- Try switching Tailwind version from v3 to v4 while using hsl format and verify it switches to oklch
- Try other format combinations to ensure they persist correctly

## Screenshots:
- Screenshot of the editor store in localstorage showing Tailwind version & color format.
![image](https://github.com/user-attachments/assets/fbd3bacd-b468-4a51-acf2-e98d22cf8970)
