### PR TITLE
Add persistence for Package Manager in code panel

### DIFF
--- a/src/components/editor/code-panel.tsx
+++ b/src/components/editor/code-panel.tsx
@@ -26,9 +26,6 @@ const CodePanel: React.FC<CodePanelProps> = ({
   themeEditorState,
   onCodePanelToggle,
 }) => {
-  const [packageManager, setPackageManager] = useState<
-    "pnpm" | "npm" | "yarn" | "bun"
-  >("pnpm");
   const [registryCopied, setRegistryCopied] = useState(false);
   const [copied, setCopied] = useState(false);
   const posthog = usePostHog();
@@ -36,8 +33,10 @@ const CodePanel: React.FC<CodePanelProps> = ({
   const preset = useEditorStore((state) => state.themeState.preset);
   const colorFormat = useEditorStore((state) => state.colorFormat);
   const tailwindVersion = useEditorStore((state) => state.tailwindVersion);
+  const packageManager = useEditorStore((state) => state.packageManager);
   const setColorFormat = useEditorStore((state) => state.setColorFormat);
   const setTailwindVersion = useEditorStore((state) => state.setTailwindVersion);
+  const setPackageManager = useEditorStore((state) => state.setPackageManager);
 
   const code = config.codeGenerator.generateComponentCode(
     themeEditorState,

--- a/src/components/editor/code-panel.tsx
+++ b/src/components/editor/code-panel.tsx
@@ -13,6 +13,7 @@ import {
 } from "../ui/select";
 import { usePostHog } from "posthog-js/react";
 import { useEditorStore } from "@/store/editor-store";
+import { usePreferencesStore } from "@/store/preferences-store";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface CodePanelProps {
@@ -31,12 +32,12 @@ const CodePanel: React.FC<CodePanelProps> = ({
   const posthog = usePostHog();
   
   const preset = useEditorStore((state) => state.themeState.preset);
-  const colorFormat = useEditorStore((state) => state.colorFormat);
-  const tailwindVersion = useEditorStore((state) => state.tailwindVersion);
-  const packageManager = useEditorStore((state) => state.packageManager);
-  const setColorFormat = useEditorStore((state) => state.setColorFormat);
-  const setTailwindVersion = useEditorStore((state) => state.setTailwindVersion);
-  const setPackageManager = useEditorStore((state) => state.setPackageManager);
+  const colorFormat = usePreferencesStore((state) => state.colorFormat);
+  const tailwindVersion = usePreferencesStore((state) => state.tailwindVersion);
+  const packageManager = usePreferencesStore((state) => state.packageManager);
+  const setColorFormat = usePreferencesStore((state) => state.setColorFormat);
+  const setTailwindVersion = usePreferencesStore((state) => state.setTailwindVersion);
+  const setPackageManager = usePreferencesStore((state) => state.setPackageManager);
 
   const code = config.codeGenerator.generateComponentCode(
     themeEditorState,

--- a/src/store/editor-store.ts
+++ b/src/store/editor-store.ts
@@ -6,13 +6,17 @@ import { defaultThemeState } from "@/config/theme";
 import { getPresetThemeStyles } from "../utils/theme-presets";
 import { ColorFormat } from "@/types";
 
+type PackageManager = "pnpm" | "npm" | "yarn" | "bun";
+
 interface EditorStore {
   themeState: ThemeEditorState;
   tailwindVersion: "3" | "4";
   colorFormat: ColorFormat;
+  packageManager: PackageManager;
   setThemeState: (state: ThemeEditorState) => void;
   setTailwindVersion: (version: "3" | "4") => void;
   setColorFormat: (format: ColorFormat) => void;
+  setPackageManager: (pm: PackageManager) => void;
   applyThemePreset: (preset: string) => void;
   resetToDefault: () => void;
   resetToCurrentPreset: () => void;
@@ -26,6 +30,7 @@ export const useEditorStore = create<EditorStore>()(
       themeState: defaultThemeState,
       tailwindVersion: "4",
       colorFormat: "oklch",
+      packageManager: "pnpm",
       setThemeState: (state: ThemeEditorState) => {
         set({ themeState: state });
       },
@@ -34,6 +39,9 @@ export const useEditorStore = create<EditorStore>()(
       },
       setColorFormat: (format: ColorFormat) => {
         set({ colorFormat: format });
+      },
+      setPackageManager: (pm: PackageManager) => {
+        set({ packageManager: pm });
       },
       applyThemePreset: (preset: string) => {
         const themeState = get().themeState;

--- a/src/store/editor-store.ts
+++ b/src/store/editor-store.ts
@@ -4,19 +4,10 @@ import { ThemeEditorState, EditorType } from "@/types/editor";
 import { isEqual } from "@ngard/tiny-isequal";
 import { defaultThemeState } from "@/config/theme";
 import { getPresetThemeStyles } from "../utils/theme-presets";
-import { ColorFormat } from "@/types";
-
-type PackageManager = "pnpm" | "npm" | "yarn" | "bun";
 
 interface EditorStore {
   themeState: ThemeEditorState;
-  tailwindVersion: "3" | "4";
-  colorFormat: ColorFormat;
-  packageManager: PackageManager;
   setThemeState: (state: ThemeEditorState) => void;
-  setTailwindVersion: (version: "3" | "4") => void;
-  setColorFormat: (format: ColorFormat) => void;
-  setPackageManager: (pm: PackageManager) => void;
   applyThemePreset: (preset: string) => void;
   resetToDefault: () => void;
   resetToCurrentPreset: () => void;
@@ -28,20 +19,8 @@ export const useEditorStore = create<EditorStore>()(
   persist(
     (set, get) => ({
       themeState: defaultThemeState,
-      tailwindVersion: "4",
-      colorFormat: "oklch",
-      packageManager: "pnpm",
       setThemeState: (state: ThemeEditorState) => {
         set({ themeState: state });
-      },
-      setTailwindVersion: (version: "3" | "4") => {
-        set({ tailwindVersion: version });
-      },
-      setColorFormat: (format: ColorFormat) => {
-        set({ colorFormat: format });
-      },
-      setPackageManager: (pm: PackageManager) => {
-        set({ packageManager: pm });
       },
       applyThemePreset: (preset: string) => {
         const themeState = get().themeState;

--- a/src/store/preferences-store.ts
+++ b/src/store/preferences-store.ts
@@ -1,0 +1,36 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { ColorFormat } from "@/types";
+
+type PackageManager = "pnpm" | "npm" | "yarn" | "bun";
+
+interface PreferencesStore {
+  tailwindVersion: "3" | "4";
+  colorFormat: ColorFormat;
+  packageManager: PackageManager;
+  setTailwindVersion: (version: "3" | "4") => void;
+  setColorFormat: (format: ColorFormat) => void;
+  setPackageManager: (pm: PackageManager) => void;
+}
+
+export const usePreferencesStore = create<PreferencesStore>()(
+  persist(
+    (set) => ({
+      tailwindVersion: "4",
+      colorFormat: "oklch",
+      packageManager: "pnpm",
+      setTailwindVersion: (version: "3" | "4") => {
+        set({ tailwindVersion: version });
+      },
+      setColorFormat: (format: ColorFormat) => {
+        set({ colorFormat: format });
+      },
+      setPackageManager: (pm: PackageManager) => {
+        set({ packageManager: pm });
+      },
+    }),
+    {
+      name: "preferences-storage", // unique name for localStorage
+    }
+  )
+); 


### PR DESCRIPTION
This PR is a sequel to https://github.com/jnsahaj/tweakcn/pull/29. I didn't realize that the package manager wasn't persisted and hence added it.

Added **Package Manager** to the editor store to make it persist after reload. Previously it was reset to the default values on reload, forcing users to change it everytime in case they used a different package manager. These new changes ensure the saving of the field into our pre-existing editor store using Zustand.

## Changes
- Extended the EditorStore interface to include packageManager as a property
- Updated the code panel component to read preferences from the store instead of using local state

## Testing Instructions
- Start the app development server (or test it in prod :P)
- Change the package manager (eg npm to bun)
- Refresh this page, or close it.
- Reopen the page in case you closed it, and ensure the previous changes are still preserved.
