### PR TITLE
refactor: Change theme-preset-select to make it reusable and extendible

### DIFF
--- a/components/editor/editor.tsx
+++ b/components/editor/editor.tsx
@@ -7,8 +7,6 @@ import { EditorConfig } from "@/types/editor";
 import { Theme, ThemeStyles } from "@/types/theme";
 import { Sliders } from "lucide-react";
 import { useEditorStore } from "@/store/editor-store";
-import { useThemePresetStore } from "@/store/theme-preset-store";
-import { authClient } from "@/lib/auth-client";
 import { ActionBar } from "./action-bar/action-bar";
 
 interface EditorProps {
@@ -31,16 +29,6 @@ const Editor: React.FC<EditorProps> = ({ config, themePromise }) => {
   const setThemeState = useEditorStore((state) => state.setThemeState);
   const Controls = config.controls;
   const Preview = config.preview;
-
-  const loadSavedPresets = useThemePresetStore((state) => state.loadSavedPresets);
-
-  const { data: session } = authClient.useSession();
-
-  useEffect(() => {
-    if (session?.user) {
-      loadSavedPresets();
-    }
-  }, [loadSavedPresets, session?.user]);
 
   const initialTheme = themePromise ? use(themePromise) : null;
 

--- a/components/editor/theme-control-panel.tsx
+++ b/components/editor/theme-control-panel.tsx
@@ -29,7 +29,6 @@ import { AlertCircle } from "lucide-react";
 import ShadowControl from "./shadow-control";
 import TabsTriggerPill from "./theme-preview/tabs-trigger-pill";
 import ThemeEditActions from "./theme-edit-actions";
-import { useThemePresetStore } from "@/store/theme-preset-store";
 import HslAdjustmentControls from "./hsl-adjustment-controls";
 
 const ThemeControlPanel = ({
@@ -38,8 +37,7 @@ const ThemeControlPanel = ({
   onChange,
   themePromise,
 }: ThemeEditorControlsProps) => {
-  const { applyThemePreset, themeState } = useEditorStore();
-  const presets = useThemePresetStore((state) => state.getAllPresets());
+  const { themeState } = useEditorStore();
 
   const currentStyles = React.useMemo(
     () => ({
@@ -85,11 +83,7 @@ const ThemeControlPanel = ({
     <>
       <div className="border-b">
         {!theme ? (
-          <ThemePresetSelect
-            presets={presets}
-            currentPreset={themeState.preset || null}
-            onPresetChange={applyThemePreset}
-          />
+          <ThemePresetSelect className="h-14 rounded-none" />
         ) : (
           <ThemeEditActions theme={theme} />
         )}

--- a/components/editor/theme-preset-select.tsx
+++ b/components/editor/theme-preset-select.tsx
@@ -1,47 +1,34 @@
-import React, { useCallback, useMemo, useState } from "react";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import { ThemePreset } from "../../types/theme";
-import { useEditorStore } from "../../store/editor-store";
-import { getPresetThemeStyles } from "../../utils/theme-preset-helper";
-import { Button } from "../ui/button";
 import {
   ArrowLeft,
   ArrowRight,
   Check,
   ChevronDown,
+  Heart,
   Moon,
   Search,
   Shuffle,
   Sun,
-  Heart,
 } from "lucide-react";
-import { useTheme } from "@/components/theme-provider";
-import { Separator } from "../ui/separator";
-import { ScrollArea } from "../ui/scroll-area";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandItem,
-} from "../ui/command";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "../ui/tooltip";
-import { Input } from "../ui/input";
-import { Badge } from "../ui/badge";
-import { cn } from "@/lib/utils";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 
-interface ThemePresetSelectProps {
-  presets: Record<string, ThemePreset>;
-  currentPreset: string | null;
-  onPresetChange: (preset: string) => void;
+import { useTheme } from "@/components/theme-provider";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Command, CommandEmpty, CommandGroup, CommandItem } from "@/components/ui/command";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { authClient } from "@/lib/auth-client";
+import { cn } from "@/lib/utils";
+import { useEditorStore } from "@/store/editor-store";
+import { useThemePresetStore } from "@/store/theme-preset-store";
+import { ThemePreset } from "@/types/theme";
+import { getPresetThemeStyles } from "@/utils/theme-preset-helper";
+
+interface ThemePresetSelectProps extends React.ComponentProps<typeof Button> {
+  withCycleThemes?: boolean;
 }
 
 interface ColorBoxProps {
@@ -49,10 +36,7 @@ interface ColorBoxProps {
 }
 
 const ColorBox: React.FC<ColorBoxProps> = ({ color }) => (
-  <div
-    className="h-3 w-3 rounded-sm border border-muted"
-    style={{ backgroundColor: color }}
-  />
+  <div className="border-muted h-3 w-3 rounded-sm border" style={{ backgroundColor: color }} />
 );
 
 interface ThemeColorsProps {
@@ -80,98 +64,161 @@ const isThemeNew = (preset: ThemePreset) => {
   return createdAt > timePeriod;
 };
 
-interface ThemeControlsProps {
-  onRandomize: () => void;
-  onThemeToggle: (event: React.MouseEvent<HTMLButtonElement>) => void;
-  theme: string;
-}
+const ThemeControls = () => {
+  const applyThemePreset = useEditorStore((store) => store.applyThemePreset);
+  const presets = useThemePresetStore((store) => store.getAllPresets());
 
-const ThemeControls: React.FC<ThemeControlsProps> = ({
-  onRandomize,
-  onThemeToggle,
-  theme,
-}) => (
-  <div className="flex gap-1">
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 w-7 p-0"
-          onClick={onThemeToggle}
-        >
-          {theme === "light" ? (
-            <Sun className="h-3.5 w-3.5" />
-          ) : (
-            <Moon className="h-3.5 w-3.5" />
-          )}
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">
-        <p className="text-xs">Toggle theme</p>
-      </TooltipContent>
-    </Tooltip>
+  const presetNames = useMemo(() => ["default", ...Object.keys(presets)], [presets]);
 
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-7 w-7 p-0"
-          onClick={onRandomize}
-        >
-          <Shuffle className="h-3.5 w-3.5" />
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">
-        <p className="text-xs">Random theme</p>
-      </TooltipContent>
-    </Tooltip>
-  </div>
-);
+  const randomize = useCallback(() => {
+    const random = Math.floor(Math.random() * presetNames.length);
+    applyThemePreset(presetNames[random]);
+  }, [presetNames]);
 
-interface ThemeCycleButtonProps {
+  const { theme, toggleTheme } = useTheme();
+  const handleThemeToggle = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const { clientX: x, clientY: y } = event;
+    toggleTheme({ x, y });
+  };
+
+  return (
+    <div className="flex gap-1">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={handleThemeToggle}>
+            {theme === "light" ? <Sun className="h-3.5 w-3.5" /> : <Moon className="h-3.5 w-3.5" />}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <p className="text-xs">Toggle theme</p>
+        </TooltipContent>
+      </Tooltip>
+
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={randomize}>
+            <Shuffle className="h-3.5 w-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <p className="text-xs">Random theme</p>
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
+};
+
+interface ThemeCycleButtonProps extends React.ComponentProps<typeof Button> {
   direction: "prev" | "next";
-  onClick: () => void;
 }
 
 const ThemeCycleButton: React.FC<ThemeCycleButtonProps> = ({
   direction,
   onClick,
+  className,
+  ...props
 }) => (
-  <>
-    <Separator orientation="vertical" className="h-8" />
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-14 shrink-0 rounded-none bg-muted/10"
-          onClick={onClick}
-        >
-          {direction === "prev" ? (
-            <ArrowLeft className="h-4 w-4" />
-          ) : (
-            <ArrowRight className="h-4 w-4" />
-          )}
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent>
-        {direction === "prev" ? "Previous theme" : "Next theme"}
-      </TooltipContent>
-    </Tooltip>
-  </>
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Button
+        variant="ghost"
+        size="icon"
+        className={cn("aspect-square h-full shrink-0", className)}
+        onClick={onClick}
+        {...props}
+      >
+        {direction === "prev" ? (
+          <ArrowLeft className="h-4 w-4" />
+        ) : (
+          <ArrowRight className="h-4 w-4" />
+        )}
+      </Button>
+    </TooltipTrigger>
+    <TooltipContent>{direction === "prev" ? "Previous theme" : "Next theme"}</TooltipContent>
+  </Tooltip>
 );
 
-const ThemePresetSelect: React.FC<ThemePresetSelectProps> = ({
-  presets,
-  currentPreset,
-  onPresetChange,
+interface ThemePresetCycleControlsProps extends React.ComponentProps<typeof Button> {
+  filteredPresets: string[];
+  currentPresetName: string;
+  className?: string;
+}
+
+const ThemePresetCycleControls: React.FC<ThemePresetCycleControlsProps> = ({
+  filteredPresets,
+  currentPresetName,
+  className,
+  ...props
 }) => {
-  const { themeState, hasUnsavedChanges } = useEditorStore();
-  const { theme, toggleTheme } = useTheme();
+  const applyThemePreset = useEditorStore((store) => store.applyThemePreset);
+
+  const currentIndex =
+    useMemo(
+      () => filteredPresets.indexOf(currentPresetName || "default"),
+      [filteredPresets, currentPresetName]
+    ) ?? 0;
+
+  const cycleTheme = useCallback(
+    (direction: "prev" | "next") => {
+      const newIndex =
+        direction === "next"
+          ? (currentIndex + 1) % filteredPresets.length
+          : (currentIndex - 1 + filteredPresets.length) % filteredPresets.length;
+      applyThemePreset(filteredPresets[newIndex]);
+    },
+    [currentIndex, filteredPresets]
+  );
+  return (
+    <>
+      <Separator orientation="vertical" className="min-h-8" />
+
+      <ThemeCycleButton
+        direction="prev"
+        size="icon"
+        className={cn("aspect-square min-h-8 w-auto", className)}
+        onClick={() => cycleTheme("prev")}
+        {...props}
+      />
+
+      <Separator orientation="vertical" className="min-h-8" />
+
+      <ThemeCycleButton
+        direction="next"
+        size="icon"
+        className={cn("aspect-square min-h-8 w-auto", className)}
+        onClick={() => cycleTheme("next")}
+        {...props}
+      />
+    </>
+  );
+};
+
+const ThemePresetSelect: React.FC<ThemePresetSelectProps> = ({
+  withCycleThemes = true,
+  className,
+  ...props
+}) => {
+  const themeState = useEditorStore((store) => store.themeState);
+  const applyThemePreset = useEditorStore((store) => store.applyThemePreset);
+  const hasUnsavedChanges = useEditorStore((store) => store.hasUnsavedChanges);
+  const currentPreset = themeState.preset;
   const mode = themeState.currentMode;
+
+  const presets = useThemePresetStore((store) => store.getAllPresets());
+  const loadSavedPresets = useThemePresetStore((store) => store.loadSavedPresets);
+  const unloadSavedPresets = useThemePresetStore((store) => store.unloadSavedPresets);
+
   const [search, setSearch] = useState("");
+
+  const { data: session } = authClient.useSession();
+
+  useEffect(() => {
+    if (session?.user) {
+      loadSavedPresets();
+    } else {
+      unloadSavedPresets();
+    }
+  }, [loadSavedPresets, session?.user]);
 
   const isSavedTheme = useCallback(
     (presetId: string) => {
@@ -180,29 +227,20 @@ const ThemePresetSelect: React.FC<ThemePresetSelectProps> = ({
     [presets]
   );
 
-  const presetNames = useMemo(
-    () => ["default", ...Object.keys(presets)],
-    [presets]
-  );
-  const value = presetNames?.find((name) => name === currentPreset);
+  const presetNames = useMemo(() => ["default", ...Object.keys(presets)], [presets]);
+  const currentPresetName = presetNames?.find((name) => name === currentPreset);
 
   const filteredPresets = useMemo(() => {
     const filteredList =
       search.trim() === ""
         ? presetNames
         : Object.entries(presets)
-            .filter(([_, preset]) =>
-              preset.label?.toLowerCase().includes(search.toLowerCase())
-            )
+            .filter(([_, preset]) => preset.label?.toLowerCase().includes(search.toLowerCase()))
             .map(([name]) => name);
 
     // Separate saved and default themes
-    const savedThemesList = filteredList.filter(
-      (name) => name !== "default" && isSavedTheme(name)
-    );
-    const defaultThemesList = filteredList.filter(
-      (name) => !savedThemesList.includes(name)
-    );
+    const savedThemesList = filteredList.filter((name) => name !== "default" && isSavedTheme(name));
+    const defaultThemesList = filteredList.filter((name) => !savedThemesList.includes(name));
 
     // Sort each list
     const sortThemes = (list: string[]) =>
@@ -216,219 +254,172 @@ const ThemePresetSelect: React.FC<ThemePresetSelectProps> = ({
     return [...sortThemes(savedThemesList), ...sortThemes(defaultThemesList)];
   }, [presetNames, search, presets, isSavedTheme]);
 
-  const currentIndex =
-    useMemo(
-      () => filteredPresets.indexOf(value || "default"),
-      [filteredPresets, value]
-    ) ?? 0;
-
-  const randomize = useCallback(() => {
-    const random = Math.floor(Math.random() * filteredPresets.length);
-    onPresetChange(filteredPresets[random]);
-  }, [onPresetChange, filteredPresets]);
-
-  const cycleTheme = useCallback(
-    (direction: "prev" | "next") => {
-      const newIndex =
-        direction === "next"
-          ? (currentIndex + 1) % filteredPresets.length
-          : (currentIndex - 1 + filteredPresets.length) %
-            filteredPresets.length;
-      onPresetChange(filteredPresets[newIndex]);
-    },
-    [currentIndex, filteredPresets, onPresetChange]
-  );
-
-  const handleThemeToggle = (event: React.MouseEvent<HTMLButtonElement>) => {
-    const { clientX: x, clientY: y } = event;
-    toggleTheme({ x, y });
-  };
-
   const filteredSavedThemes = useMemo(() => {
-    return filteredPresets.filter(
-      (name) => name !== "default" && isSavedTheme(name)
-    );
+    return filteredPresets.filter((name) => name !== "default" && isSavedTheme(name));
   }, [filteredPresets, isSavedTheme]);
 
   const filteredDefaultThemes = useMemo(() => {
-    return filteredPresets.filter(
-      (name) => name === "default" || !isSavedTheme(name)
-    );
+    return filteredPresets.filter((name) => name === "default" || !isSavedTheme(name));
   }, [filteredPresets, isSavedTheme]);
 
   return (
-    <div className="flex items-center">
-      <TooltipProvider>
-        <Popover>
-          <PopoverTrigger className="bg-muted/10" asChild>
-            <Button
-              variant="ghost"
-              className={cn(
-                "w-full md:min-w-56 min-h-14 rounded-none justify-between group relative"
-              )}
-            >
-              <div className="flex items-center gap-3">
-                <div className="flex gap-0.5">
-                  <ColorBox color={themeState.styles[mode].primary} />
-                  <ColorBox color={themeState.styles[mode].accent} />
-                  <ColorBox color={themeState.styles[mode].secondary} />
-                  <ColorBox color={themeState.styles[mode].border} />
-                </div>
-                {value !== "default" &&
-                  value &&
-                  isSavedTheme(value) &&
-                  !hasUnsavedChanges() && (
-                    <div className="rounded-full bg-muted p-1">
-                      <Heart
-                        className="size-1"
-                        stroke="var(--muted)"
-                        fill="var(--muted-foreground)"
-                      />
-                    </div>
-                  )}
-                <span className="capitalize font-medium">
-                  {hasUnsavedChanges() ? (
-                    <>Custom (Unsaved)</>
-                  ) : (
-                    presets[value || "default"]?.label || "default"
-                  )}
-                </span>
+    <div className="flex w-full items-center">
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost"
+            className={cn("group relative w-full justify-between md:min-w-56", className)}
+            {...props}
+          >
+            <div className="flex w-full items-center gap-3 overflow-hidden">
+              <div className="flex gap-0.5">
+                <ColorBox color={themeState.styles[mode].primary} />
+                <ColorBox color={themeState.styles[mode].accent} />
+                <ColorBox color={themeState.styles[mode].secondary} />
+                <ColorBox color={themeState.styles[mode].border} />
               </div>
-              <ChevronDown className="size-4 shrink-0" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="p-0 w-[300px] ml-4" align="center">
-            <Command className="rounded-lg border shadow-md w-full">
-              <div className="flex items-center w-full">
-                <div className="flex items-center w-full border-b px-3 py-1">
-                  <Search className="size-4 shrink-0 opacity-50" />
-                  <Input
-                    placeholder="Search themes..."
-                    className="shadow-none border-0 focus-visible:ring-0 focus-visible:ring-offset-0"
-                    value={search}
-                    onChange={(e) => setSearch(e.target.value)}
-                  />
-                </div>
-              </div>
-              <div className="flex items-center justify-between px-4 py-2">
-                <div className="text-xs text-muted-foreground">
-                  {filteredPresets.length} theme
-                  {filteredPresets.length !== 1 ? "s" : ""}
-                </div>
-                <ThemeControls
-                  onRandomize={randomize}
-                  onThemeToggle={handleThemeToggle}
-                  theme={theme}
+              {currentPresetName !== "default" &&
+                currentPresetName &&
+                isSavedTheme(currentPresetName) &&
+                !hasUnsavedChanges() && (
+                  <div className="bg-muted rounded-full p-1">
+                    <Heart
+                      className="size-1"
+                      stroke="var(--muted)"
+                      fill="var(--muted-foreground)"
+                    />
+                  </div>
+                )}
+              <span className="truncate text-left font-medium capitalize">
+                {hasUnsavedChanges() ? (
+                  <>Custom (Unsaved)</>
+                ) : (
+                  presets[currentPresetName || "default"]?.label || "default"
+                )}
+              </span>
+            </div>
+            <ChevronDown className="size-4 shrink-0" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[300px] p-0" align="center">
+          <Command className="h-100 w-full rounded-lg border shadow-md">
+            <div className="flex w-full items-center">
+              <div className="flex w-full items-center border-b px-3 py-1">
+                <Search className="size-4 shrink-0 opacity-50" />
+                <Input
+                  placeholder="Search themes..."
+                  className="border-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
                 />
               </div>
-              <Separator />
-              <ScrollArea className="h-[500px] max-h-[70vh]">
-                <CommandEmpty>No themes found.</CommandEmpty>
+            </div>
+            <div className="flex items-center justify-between px-4 py-2">
+              <div className="text-muted-foreground text-xs">
+                {filteredPresets.length} theme
+                {filteredPresets.length !== 1 ? "s" : ""}
+              </div>
+              <ThemeControls />
+            </div>
+            <Separator />
+            <ScrollArea className="h-[500px] max-h-[70vh]">
+              <CommandEmpty>No themes found.</CommandEmpty>
 
-                {/* Saved Themes Group */}
-                {filteredSavedThemes.length > 0 && (
-                  <>
-                    <CommandGroup heading="Saved Themes">
-                      {filteredSavedThemes
-                        .filter(
-                          (name) => name !== "default" && isSavedTheme(name)
-                        )
-                        .map((presetName, index) => (
-                          <>
-                            <CommandItem
-                              key={`${presetName}-${index}`}
-                              value={`${presetName}-${index}`}
-                              onSelect={() => {
-                                onPresetChange(presetName);
-                                setSearch("");
-                              }}
-                              className="flex items-center gap-2 py-2 data-[highlighted]:bg-secondary/50"
-                            >
-                              <ThemeColors
-                                presetName={presetName}
-                                mode={mode}
-                              />
-                              <div className="flex items-center gap-2 flex-1">
-                                <span className="capitalize text-sm font-medium">
-                                  {presets[presetName]?.label || presetName}
-                                </span>
-                                {presets[presetName] &&
-                                  isThemeNew(presets[presetName]) && (
-                                    <Badge
-                                      variant="secondary"
-                                      className="text-xs rounded-full"
-                                    >
-                                      New
-                                    </Badge>
-                                  )}
-                              </div>
-                              {presetName === value && (
-                                <Check className="h-4 w-4 shrink-0 opacity-70" />
+              {/* Saved Themes Group */}
+              {filteredSavedThemes.length > 0 && (
+                <>
+                  <CommandGroup heading="Saved Themes">
+                    {filteredSavedThemes
+                      .filter((name) => name !== "default" && isSavedTheme(name))
+                      .map((presetName, index) => (
+                        <>
+                          <CommandItem
+                            key={`${presetName}-${index}`}
+                            value={`${presetName}-${index}`}
+                            onSelect={() => {
+                              applyThemePreset(presetName);
+                              setSearch("");
+                            }}
+                            className="data-[highlighted]:bg-secondary/50 flex items-center gap-2 py-2"
+                          >
+                            <ThemeColors presetName={presetName} mode={mode} />
+                            <div className="flex flex-1 items-center gap-2">
+                              <span className="line-clamp-1 text-sm font-medium capitalize">
+                                {presets[presetName]?.label || presetName}
+                              </span>
+                              {presets[presetName] && isThemeNew(presets[presetName]) && (
+                                <Badge variant="secondary" className="rounded-full text-xs">
+                                  New
+                                </Badge>
                               )}
-                            </CommandItem>
-                          </>
-                        ))}
-                    </CommandGroup>
-                    <Separator className="my-2" />
-                  </>
-                )}
-
-                {filteredSavedThemes.length === 0 && search.trim() === "" && (
-                  <>
-                    <div className="pt-2 px-2 text-xs text-muted-foreground flex items-center gap-1.5">
-                      <div className="flex items-center gap-1 px-2 py-1 border rounded-md">
-                        <Heart className="size-3" />
-                        <span>Save</span>
-                      </div>
-                      <span>a theme to find it here.</span>
-                    </div>
-                    <Separator className="my-2" />
-                  </>
-                )}
-
-                {/* Default Theme Group */}
-                {filteredDefaultThemes.length > 0 && (
-                  <CommandGroup heading="Built-in Themes">
-                    {filteredDefaultThemes.map((presetName, index) => (
-                      <CommandItem
-                        key={`${presetName}-${index}`}
-                        value={`${presetName}-${index}`}
-                        onSelect={() => {
-                          onPresetChange(presetName);
-                          setSearch("");
-                        }}
-                        className="flex items-center gap-2 py-2 data-[highlighted]:bg-secondary/50"
-                      >
-                        <ThemeColors presetName={presetName} mode={mode} />
-                        <div className="flex items-center gap-2 flex-1">
-                          <span className="capitalize text-sm font-medium">
-                            {presets[presetName]?.label || presetName}
-                          </span>
-                          {presets[presetName] &&
-                            isThemeNew(presets[presetName]) && (
-                              <Badge
-                                variant="secondary"
-                                className="text-xs rounded-full"
-                              >
-                                New
-                              </Badge>
+                            </div>
+                            {presetName === currentPresetName && (
+                              <Check className="h-4 w-4 shrink-0 opacity-70" />
                             )}
-                        </div>
-                        {presetName === value && (
-                          <Check className="h-4 w-4 shrink-0 opacity-70" />
-                        )}
-                      </CommandItem>
-                    ))}
+                          </CommandItem>
+                        </>
+                      ))}
                   </CommandGroup>
-                )}
-              </ScrollArea>
-            </Command>
-          </PopoverContent>
-        </Popover>
-      </TooltipProvider>
+                  <Separator className="my-2" />
+                </>
+              )}
 
-      <ThemeCycleButton direction="prev" onClick={() => cycleTheme("prev")} />
-      <ThemeCycleButton direction="next" onClick={() => cycleTheme("next")} />
+              {filteredSavedThemes.length === 0 && search.trim() === "" && (
+                <>
+                  <div className="text-muted-foreground flex items-center gap-1.5 px-2 pt-2 text-xs">
+                    <div className="flex items-center gap-1 rounded-md border px-2 py-1">
+                      <Heart className="size-3" />
+                      <span>Save</span>
+                    </div>
+                    <span>a theme to find it here.</span>
+                  </div>
+                  <Separator className="my-2" />
+                </>
+              )}
+
+              {/* Default Theme Group */}
+              {filteredDefaultThemes.length > 0 && (
+                <CommandGroup heading="Built-in Themes">
+                  {filteredDefaultThemes.map((presetName, index) => (
+                    <CommandItem
+                      key={`${presetName}-${index}`}
+                      value={`${presetName}-${index}`}
+                      onSelect={() => {
+                        applyThemePreset(presetName);
+                        setSearch("");
+                      }}
+                      className="data-[highlighted]:bg-secondary/50 flex items-center gap-2 py-2"
+                    >
+                      <ThemeColors presetName={presetName} mode={mode} />
+                      <div className="flex flex-1 items-center gap-2">
+                        <span className="text-sm font-medium capitalize">
+                          {presets[presetName]?.label || presetName}
+                        </span>
+                        {presets[presetName] && isThemeNew(presets[presetName]) && (
+                          <Badge variant="secondary" className="rounded-full text-xs">
+                            New
+                          </Badge>
+                        )}
+                      </div>
+                      {presetName === currentPresetName && (
+                        <Check className="h-4 w-4 shrink-0 opacity-70" />
+                      )}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              )}
+            </ScrollArea>
+          </Command>
+        </PopoverContent>
+      </Popover>
+
+      {withCycleThemes && (
+        <ThemePresetCycleControls
+          filteredPresets={filteredPresets}
+          currentPresetName={currentPresetName || "default"}
+          className={className}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## What changed?
* Removed code and imports not needed anymore
* The components worry about their own state leveraging global state stores, instead of worrying about syncing two different instances passing the same props.
* Long theme names won't overflow and cause it to break in two or more lines.
* Saved themes now get unloaded when login out, before they would persist.

### Notes:
* The functionality did not change, to the outside it works exactly the same.
* I know it seems like huge changes, but it's mostly prettier formatting the code.