### PR TITLE
refactor: use undo/redo directly from Editor Store instead of dependi…

### DIFF
--- a/components/editor/action-bar/components/undo-redo-buttons.tsx
+++ b/components/editor/action-bar/components/undo-redo-buttons.tsx
@@ -1,17 +1,17 @@
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { useDialogActions } from "@/hooks/use-dialog-actions";
+import { useEditorStore } from "@/store/editor-store";
 import { Redo, Undo } from "lucide-react";
 
 export function UndoRedoButtons() {
-  const { handleUndo, handleRedo, canUndo, canRedo } = useDialogActions();
+  const { undo, redo, canUndo, canRedo } = useEditorStore();
 
   return (
     <TooltipProvider>
       <div className="flex items-center gap-1">
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon" onClick={handleUndo} disabled={!canUndo}>
+            <Button variant="ghost" size="icon" onClick={undo} disabled={!canUndo()}>
               <Undo className="h-4 w-4" />
             </Button>
           </TooltipTrigger>
@@ -21,7 +21,7 @@ export function UndoRedoButtons() {
         </Tooltip>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="ghost" size="icon" onClick={handleRedo} disabled={!canRedo}>
+            <Button variant="ghost" size="icon" onClick={redo} disabled={!canRedo()}>
               <Redo className="h-4 w-4" />
             </Button>
           </TooltipTrigger>

--- a/hooks/use-dialog-actions.tsx
+++ b/hooks/use-dialog-actions.tsx
@@ -42,10 +42,6 @@ interface DialogActionsContextType {
   handleGenerateTheme: (promptText: string, jsonPromptText: string) => Promise<void>;
   handleShareClick: (id?: string) => Promise<void>;
   saveTheme: (themeName: string) => Promise<void>;
-  handleUndo: () => void;
-  handleRedo: () => void;
-  canUndo: boolean;
-  canRedo: boolean;
 }
 
 function useDialogActionsStore(): DialogActionsContextType {
@@ -63,10 +59,6 @@ function useDialogActionsStore(): DialogActionsContextType {
     setThemeState,
     applyThemePreset,
     hasThemeChangedFromCheckpoint,
-    undo,
-    redo,
-    canUndo: editorCanUndo,
-    canRedo: editorCanRedo,
   } = useEditorStore();
   const { getPreset } = useThemePresetStore();
   const { data: session } = authClient.useSession();
@@ -87,14 +79,6 @@ function useDialogActionsStore(): DialogActionsContextType {
     setSaveDialogOpen(true);
     setShareAfterSave(true);
   });
-
-  const handleUndo = () => {
-    undo();
-  };
-
-  const handleRedo = () => {
-    redo();
-  };
 
   const handleGenerateTheme = async (promptText: string, jsonPromptText: string) => {
     if (!promptText.trim()) return;
@@ -235,10 +219,6 @@ function useDialogActionsStore(): DialogActionsContextType {
     handleGenerateTheme,
     handleShareClick,
     saveTheme,
-    handleUndo,
-    handleRedo,
-    canUndo: editorCanUndo(),
-    canRedo: editorCanRedo(),
   };
 
   return value;


### PR DESCRIPTION
# What does this PR do?
It changes how the editor `undo, redo, canUndo, canRedo` functionality is consumed in `<UndoRedoButtons/>`.  Now the methods are correctly consumed from `useEditorStore()` instead of a wrapper (unrelated) hook.

I noticed your were consuming these methods from `useDialogActions()` hook, which made no sense because that's a hook to handle Dialog state and the auth wall.