### PR TITLE
refactor: conditionally render 'oklch' color format based on Tailwind…

### DIFF
--- a/components/editor/code-panel.tsx
+++ b/components/editor/code-panel.tsx
@@ -43,6 +43,9 @@ const CodePanel: React.FC<CodePanelProps> = ({ themeEditorState }) => {
   const isSavedPreset = useThemePresetStore(
     (state) => preset && state.getPreset(preset)?.source === "SAVED"
   );
+  const getAvailableColorFormats = usePreferencesStore(
+    (state) => state.getAvailableColorFormats
+  );
 
   const code = generateThemeCode(
     themeEditorState,
@@ -194,10 +197,11 @@ const CodePanel: React.FC<CodePanelProps> = ({ themeEditorState }) => {
             <SelectValue className="focus:ring-transparent" />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="hsl">hsl</SelectItem>
-            {tailwindVersion === "4" && <SelectItem value="oklch">oklch</SelectItem>}
-            <SelectItem value="rgb">rgb</SelectItem>
-            <SelectItem value="hex">hex</SelectItem>
+            {getAvailableColorFormats().map((colorFormat) => (
+              <SelectItem key={colorFormat} value={colorFormat}>
+                {colorFormat}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </div>

--- a/components/editor/code-panel.tsx
+++ b/components/editor/code-panel.tsx
@@ -195,7 +195,7 @@ const CodePanel: React.FC<CodePanelProps> = ({ themeEditorState }) => {
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="hsl">hsl</SelectItem>
-            <SelectItem value="oklch">oklch</SelectItem>
+            {tailwindVersion === "4" && <SelectItem value="oklch">oklch</SelectItem>}
             <SelectItem value="rgb">rgb</SelectItem>
             <SelectItem value="hex">hex</SelectItem>
           </SelectContent>


### PR DESCRIPTION
… version

Closes #81 

- Automatically switches color format to hsl if user switches from v4/oklch to v3.
- We do not show the oklch option when Tailwind v3 is selected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The color format dropdown now dynamically displays available options based on the selected Tailwind CSS version.
- **Bug Fixes**
  - Prevented selection of unsupported color formats when switching between Tailwind CSS versions, ensuring only valid options are available.
- **Chores**
  - Improved validation and consistency between Tailwind version and color format preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->