### PR TITLE
Fix Issue #133: Theme generated with AI has --spacing: undefined

### DIFF
--- a/components/editor/ai/message-controls.tsx
+++ b/components/editor/ai/message-controls.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { useEditorStore } from "@/store/editor-store";
 import { type ChatMessage as ChatMessageType } from "@/types/ai";
 import { ThemeStyles } from "@/types/theme";
+import { mergeThemeStylesWithDefaults } from "@/utils/theme-styles";
 import { Goal, RefreshCw } from "lucide-react";
 
 type MessageControlsProps = {
@@ -24,7 +25,7 @@ export function MessageControls({ message, onRetry }: MessageControlsProps) {
 
     setThemeState({
       ...themeState,
-      styles: themeStyles,
+      styles: mergeThemeStylesWithDefaults(themeStyles),
     });
   };
 

--- a/lib/ai/ai-theme-generator.ts
+++ b/lib/ai/ai-theme-generator.ts
@@ -1,8 +1,8 @@
-import { defaultThemeState } from "@/config/theme";
 import { useEditorStore } from "@/store/editor-store";
 import { AIPromptData } from "@/types/ai";
 import { Theme } from "@/types/theme";
 import { buildPromptForAPI } from "@/utils/ai/ai-prompt";
+import { mergeThemeStylesWithDefaults } from "@/utils/theme-styles";
 
 /**
  * Generate a theme with AI using a text prompt
@@ -42,27 +42,20 @@ export async function generateThemeWithAI(prompt: string, options?: { signal?: A
 export function applyGeneratedTheme(themeStyles: Theme["styles"]) {
   const { themeState, setThemeState } = useEditorStore.getState();
 
+  // Merge the generated theme styles with the default theme styles
+  // if the generated theme styles are missing a value, use the default theme styles
+  const mergedStyles = mergeThemeStylesWithDefaults(themeStyles);
+
   if (!document.startViewTransition) {
     setThemeState({
       ...themeState,
-      styles: {
-        ...themeState.styles,
-        light: { ...defaultThemeState.styles.light, ...themeStyles.light },
-        dark: { ...defaultThemeState.styles.dark, ...themeStyles.dark },
-      },
+      styles: mergedStyles,
     });
   } else {
     document.startViewTransition(() => {
       setThemeState({
         ...themeState,
-        styles: {
-          ...themeState.styles,
-          light: {
-            ...defaultThemeState.styles.light,
-            ...themeStyles.light,
-          },
-          dark: { ...defaultThemeState.styles.dark, ...themeStyles.dark },
-        },
+        styles: mergedStyles,
       });
     });
   }

--- a/utils/theme-style-generator.ts
+++ b/utils/theme-style-generator.ts
@@ -96,14 +96,13 @@ const generateThemeVariables = (
     getShadowMap({ styles: themeStyles, currentMode: mode })
   );
   const spacingVar =
-    mode === "light" && themeStyles["light"].spacing !== defaultLightThemeStyles.spacing
-      ? `\n  --spacing: ${themeStyles["light"].spacing};`
+    mode === "light"
+      ? `\n  --spacing: ${themeStyles["light"].spacing ?? defaultLightThemeStyles.spacing};`
       : "";
 
   const trackingVars =
-    mode === "light" &&
-    themeStyles["light"]["letter-spacing"] !== defaultLightThemeStyles["letter-spacing"]
-      ? `\n  --tracking-normal: ${themeStyles["light"]["letter-spacing"]};`
+    mode === "light"
+      ? `\n  --tracking-normal: ${themeStyles["light"]["letter-spacing"] ?? defaultLightThemeStyles["letter-spacing"]};`
       : "";
 
   return (

--- a/utils/theme-styles.ts
+++ b/utils/theme-styles.ts
@@ -1,0 +1,11 @@
+import { defaultThemeState } from "@/config/theme";
+import { ThemeStyles } from "@/types/theme";
+
+export function mergeThemeStylesWithDefaults(themeStyles: ThemeStyles) {
+  const mergedStyles = {
+    ...defaultThemeState.styles,
+    light: { ...defaultThemeState.styles.light, ...themeStyles.light },
+    dark: { ...defaultThemeState.styles.dark, ...themeStyles.dark },
+  };
+  return mergedStyles;
+}


### PR DESCRIPTION
### Fix #133:  Theme generated with AI has --spacing: undefined
When generating the theme from the AI chat, the spacing was set to undefined because the `spacing` property is being ommited in the response schema we get as the output.

## Changes:
* I merged the Default theme styles and the generated styles to override them. If a property is ommited when generating the AI theme, then the default value will be used. 
* The UI Message controls to 'restore' to checkpoint correctly applies the default styles too, there was also a bug where restoring to a checkpoint would chanmge the CSS vars but it would not change the actual spacing on the website.

![spacing undefined](https://github.com/user-attachments/assets/3b8e57a9-feda-4d91-8296-c6495a5c2800)
![spacing fixed](https://github.com/user-attachments/assets/f7657180-14ac-4d1b-9df4-2e443b59d978)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved theme customization by ensuring that custom theme styles are now merged with default styles, preserving default values when resetting or applying themes.
* **Refactor**
  * Centralized and simplified the logic for merging theme styles with defaults for a more consistent user experience.
* **Style**
  * Updated the generation of CSS properties for spacing and letter-spacing to ensure consistent fallback to default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->