### PR TITLE
fix(header): correct mobile theme toggle icon logic

### DIFF
--- a/components/home/header.tsx
+++ b/components/home/header.tsx
@@ -133,9 +133,9 @@ export function Header({
             className="rounded-full cursor-pointer"
           >
             {theme === "dark" ? (
-              <Sun className="size-[18px]" />
-            ) : (
               <Moon className="size-[18px]" />
+            ) : (
+              <Sun className="size-[18px]" />
             )}
           </Button>
           <Button


### PR DESCRIPTION
Show Moon icon in dark mode and Sun icon in light mode for mobile theme toggle, matching desktop behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the theme toggle icon in the mobile header to consistently display the Sun icon for the light theme and the Moon icon for the dark theme, matching the desktop behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->