### PR TITLE
fix: improve number input UX for decimal editing and locale support

### DIFF
--- a/components/editor/slider-with-input.tsx
+++ b/components/editor/slider-with-input.tsx
@@ -20,11 +20,20 @@ export const SliderWithInput = ({
   label: string;
   unit?: string;
 }) => {
-  const [localValue, setLocalValue] = useState(value);
+  const [localValue, setLocalValue] = useState(value.toString());
 
   useEffect(() => {
-    setLocalValue(value);
+    setLocalValue(value.toString());
   }, [value]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value;
+    setLocalValue(raw);
+    const num = parseFloat(raw.replace(',', '.'));
+    if (!isNaN(num)) {
+      onChange(Math.max(min, Math.min(max, num)));
+    }
+  };
 
   return (
     <div className="mb-3">
@@ -40,11 +49,8 @@ export const SliderWithInput = ({
             id={`input-${label.replace(/\s+/g, "-").toLowerCase()}`}
             type="number"
             value={localValue}
-            onChange={(e) => {
-              const newValue = Number(e.target.value);
-              setLocalValue(newValue);
-              onChange(newValue);
-            }}
+            onChange={handleChange}
+            onBlur={() => setLocalValue(value.toString())}
             min={min}
             max={max}
             step={step}
@@ -55,13 +61,14 @@ export const SliderWithInput = ({
       </div>
       <Slider
         id={`slider-${label.replace(/\s+/g, "-").toLowerCase()}`}
-        value={[localValue]}
+        value={[value]}
         min={min}
         max={max}
         step={step}
         onValueChange={(values) => {
-          setLocalValue(values[0]);
-          onChange(values[0]);
+          const newValue = values[0];
+          setLocalValue(newValue.toString());
+          onChange(newValue);
         }}
         className="py-1"
       />


### PR DESCRIPTION
## Problem
The current number input behavior in `slider-with-input` creates a frustrating ux, especially for decimal values:

- Decimal periods don't work at all in Swedish locale (and likely other European locales) - only commas work. I initially thought the input was broken
- Editing decimals like `0.5` → `1.5` requires awkward workarounds (backspace to 0, type 1, get "01", type comma, get "01,5")
- Backspace behavior forces values to 0, preventing natural text selection and replacement

## Solution
- Store input value as string to allow intermediate states during typing
- Convert commas to periods for broader locale support  
- Add bounds checking and validation
- Reset display value on blur to maintain clean state
- Fix slider synchronization to use validated value

## Result
Natural typing experience that works across locales, with proper validation and bounds checking maintained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of number input to better support partial and invalid entries, including support for commas as decimal separators.
  * Enhanced synchronization between the slider and input field for more consistent and reliable value updates.
  * Ensured input display resets to the correct value after editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->