### PR TITLE
Refactor Preview Panel Defaults and Ergonomics

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -63,6 +63,7 @@
 }
 
 * {
+  color-scheme: light dark;
   border-color: var(--color-border);
 }
 

--- a/components/editor/action-bar/components/theme-toggle.tsx
+++ b/components/editor/action-bar/components/theme-toggle.tsx
@@ -1,7 +1,8 @@
-import { Moon, Sun } from "lucide-react";
-import * as SwitchPrimitives from "@radix-ui/react-switch";
 import { useTheme } from "@/components/theme-provider";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { TooltipWrapper } from "@/components/tooltip-wrapper";
+import { cn } from "@/lib/utils";
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+import { Moon, Sun } from "lucide-react";
 
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
@@ -13,21 +14,24 @@ export function ThemeToggle() {
 
   return (
     <div className="px-2">
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <SwitchPrimitives.Root
-            aria-label="Toggle theme"
-            checked={theme === "dark"}
-            className="peer focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:bg-accent data-[state=unchecked]:bg-input inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
-            onClick={handleThemeToggle}
+      <TooltipWrapper label="Toggle light/dark mode" asChild>
+        <SwitchPrimitives.Root
+          checked={theme === "dark"}
+          onClick={handleThemeToggle}
+          className={cn(
+            "peer focus-visible:ring-ring focus-visible:ring-offset-background inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+            theme === "dark" ? "bg-primary" : "bg-input"
+          )}
+        >
+          <SwitchPrimitives.Thumb
+            className={cn(
+              "bg-background pointer-events-none flex size-5 items-center justify-center rounded-full shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+            )}
           >
-            <SwitchPrimitives.Thumb className="bg-background pointer-events-none flex h-5 w-5 items-center justify-center rounded-full shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0">
-              {theme === "dark" ? <Moon className="size-3" /> : <Sun className="size-3" />}
-            </SwitchPrimitives.Thumb>
-          </SwitchPrimitives.Root>
-        </TooltipTrigger>
-        <TooltipContent>Toggle light/dark mode</TooltipContent>
-      </Tooltip>
+            {theme === "dark" ? <Moon className="size-3" /> : <Sun className="size-3" />}
+          </SwitchPrimitives.Thumb>
+        </SwitchPrimitives.Root>
+      </TooltipWrapper>
     </div>
   );
 }

--- a/components/editor/theme-preview-panel.tsx
+++ b/components/editor/theme-preview-panel.tsx
@@ -2,25 +2,24 @@
 
 import ShadcnBlocksLogo from "@/assets/shadcnblocks.svg";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
-import { Tabs, TabsList } from "@/components/ui/tabs";
+import { Tabs, TabsContent, TabsList } from "@/components/ui/tabs";
 import { useFullscreen } from "@/hooks/use-fullscreen";
 import { useThemeInspector } from "@/hooks/use-theme-inspector";
 import { cn } from "@/lib/utils";
 import { ThemeEditorPreviewProps } from "@/types/theme";
-import { TabsContent as TabsContentPrimitive } from "@radix-ui/react-tabs";
 import { Inspect, Maximize, Minimize, MoreVertical } from "lucide-react";
 import Link from "next/link";
 import { lazy, useState } from "react";
 import { HorizontalScrollArea } from "../horizontal-scroll-area";
 import { ThemeToggle } from "../theme-toggle";
 import { TooltipWrapper } from "../tooltip-wrapper";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "../ui/dropdown-menu";
 import InspectorOverlay from "./inspector-overlay";
 import ColorPreview from "./theme-preview/color-preview";
 import ExamplesPreviewContainer from "./theme-preview/examples-preview-container";
@@ -157,19 +156,19 @@ const ThemePreviewPanel = ({ styles, currentMode }: ThemeEditorPreviewProps) => 
             onMouseLeave={handleMouseLeave}
           >
             <div className="flex h-full flex-1 flex-col">
-              <TabsContentPrimitive value="cards" className="m-0 h-full">
+              <TabsContent value="cards" className="m-0 h-full">
                 <ExamplesPreviewContainer>
                   <DemoCards />
                 </ExamplesPreviewContainer>
-              </TabsContentPrimitive>
+              </TabsContent>
 
-              <TabsContentPrimitive value="dashboard" className="@container mt-0 h-full space-y-6">
+              <TabsContent value="dashboard" className="@container mt-0 h-full space-y-6">
                 <ExamplesPreviewContainer className="min-w-[1400px]">
                   <DemoDashboard />
                 </ExamplesPreviewContainer>
-              </TabsContentPrimitive>
+              </TabsContent>
 
-              <TabsContentPrimitive value="pricing" className="@container mt-0 h-full space-y-6">
+              <TabsContent value="pricing" className="@container mt-0 h-full space-y-6">
                 <ExamplesPreviewContainer>
                   <div className="absolute top-4 right-4 z-10">
                     <Link
@@ -194,35 +193,35 @@ const ThemePreviewPanel = ({ styles, currentMode }: ThemeEditorPreviewProps) => 
                   </div>
                   <DemoPricing />
                 </ExamplesPreviewContainer>
-              </TabsContentPrimitive>
+              </TabsContent>
 
-              <TabsContentPrimitive value="mail" className="@container mt-0 h-full space-y-6">
+              <TabsContent value="mail" className="@container mt-0 h-full space-y-6">
                 <ExamplesPreviewContainer className="min-w-[1300px]">
                   <DemoMail />
                 </ExamplesPreviewContainer>
-              </TabsContentPrimitive>
+              </TabsContent>
 
-              <TabsContentPrimitive value="tasks" className="@container mt-0 h-full space-y-6">
+              <TabsContent value="tasks" className="@container mt-0 h-full space-y-6">
                 <ExamplesPreviewContainer className="min-w-[1300px]">
                   <DemoTasks />
                 </ExamplesPreviewContainer>
-              </TabsContentPrimitive>
+              </TabsContent>
 
-              <TabsContentPrimitive value="music" className="@container mt-0 h-full space-y-6">
+              <TabsContent value="music" className="@container mt-0 h-full space-y-6">
                 <ExamplesPreviewContainer className="min-w-[1300px]">
                   <DemoMusic />
                 </ExamplesPreviewContainer>
-              </TabsContentPrimitive>
+              </TabsContent>
 
-              <TabsContentPrimitive value="typography" className="space-y-6 p-4">
+              <TabsContent value="typography" className="space-y-6 p-4">
                 <ExamplesPreviewContainer>
                   <TypographyDemo />
                 </ExamplesPreviewContainer>
-              </TabsContentPrimitive>
+              </TabsContent>
 
-              <TabsContentPrimitive value="colors" className="space-y-6 p-4">
+              <TabsContent value="colors" className="space-y-6 p-4">
                 <ColorPreview styles={styles} currentMode={currentMode} />
-              </TabsContentPrimitive>
+              </TabsContent>
 
               <ScrollBar orientation="horizontal" />
             </div>

--- a/components/editor/theme-preview-panel.tsx
+++ b/components/editor/theme-preview-panel.tsx
@@ -27,8 +27,6 @@ import TabsTriggerPill from "./theme-preview/tabs-trigger-pill";
 
 const DemoCards = lazy(() => import("@/components/examples/cards"));
 const DemoMail = lazy(() => import("@/components/examples/mail"));
-const DemoTasks = lazy(() => import("@/components/examples/tasks"));
-const DemoMusic = lazy(() => import("@/components/examples/music"));
 const DemoDashboard = lazy(() => import("@/components/examples/dashboard"));
 const DemoPricing = lazy(() => import("@/components/examples/pricing/pricing"));
 const TypographyDemo = lazy(() => import("@/components/examples/typography/typography-demo"));
@@ -70,6 +68,7 @@ const ThemePreviewPanel = ({ styles, currentMode }: ThemeEditorPreviewProps) => 
           <HorizontalScrollArea className="mt-2 mb-1 flex w-full items-center justify-between px-4">
             <TabsList className="bg-background text-muted-foreground inline-flex w-fit items-center justify-center rounded-full px-0">
               <TabsTriggerPill value="cards">Cards</TabsTriggerPill>
+
               <div className="hidden md:flex">
                 <TabsTriggerPill value="dashboard">Dashboard</TabsTriggerPill>
                 <TabsTriggerPill value="mail">Mail</TabsTriggerPill>
@@ -88,18 +87,6 @@ const ThemePreviewPanel = ({ styles, currentMode }: ThemeEditorPreviewProps) => 
                 <DropdownMenuContent align="end">
                   <DropdownMenuItem onClick={() => handleTabChange("typography")}>
                     Typography
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => handleTabChange("tasks")}
-                    className="hidden md:flex"
-                  >
-                    Tasks
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => handleTabChange("music")}
-                    className="hidden md:flex"
-                  >
-                    Music
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
@@ -120,7 +107,7 @@ const ThemePreviewPanel = ({ styles, currentMode }: ThemeEditorPreviewProps) => 
                   size="sm"
                   onClick={toggleInspector}
                   className={cn(
-                    "group h-8 w-8",
+                    "group size-8",
                     inspectorEnabled && "bg-accent text-accent-foreground w-auto"
                   )}
                 >
@@ -149,27 +136,32 @@ const ThemePreviewPanel = ({ styles, currentMode }: ThemeEditorPreviewProps) => 
             </div>
           </HorizontalScrollArea>
 
-          <ScrollArea
-            className="relative m-4 mt-1 flex flex-1 flex-col overflow-hidden rounded-lg border"
-            ref={rootRef}
-            onMouseMove={handleMouseMove}
-            onMouseLeave={handleMouseLeave}
-          >
-            <div className="flex h-full flex-1 flex-col">
-              <TabsContent value="cards" className="m-0 h-full">
-                <ExamplesPreviewContainer>
-                  <DemoCards />
+          <section className="relative size-full overflow-hidden p-4 pt-1">
+            <div
+              className="relative isolate size-full overflow-hidden rounded-lg border"
+              ref={rootRef}
+              onMouseMove={handleMouseMove}
+              onMouseLeave={handleMouseLeave}
+            >
+              <TabsContent value="cards" className="m-0 size-full">
+                <ExamplesPreviewContainer className="size-full">
+                  <ScrollArea className="size-full">
+                    <DemoCards />
+                  </ScrollArea>
                 </ExamplesPreviewContainer>
               </TabsContent>
 
-              <TabsContent value="dashboard" className="@container mt-0 h-full space-y-6">
-                <ExamplesPreviewContainer className="min-w-[1400px]">
-                  <DemoDashboard />
+              <TabsContent value="dashboard" className="@container m-0 size-full">
+                <ExamplesPreviewContainer className="size-full">
+                  <ScrollArea className="size-full">
+                    <DemoDashboard />
+                    <ScrollBar orientation="horizontal" />
+                  </ScrollArea>
                 </ExamplesPreviewContainer>
               </TabsContent>
 
               <TabsContent value="pricing" className="@container mt-0 h-full space-y-6">
-                <ExamplesPreviewContainer>
+                <ExamplesPreviewContainer className="size-full">
                   <div className="absolute top-4 right-4 z-10">
                     <Link
                       href="https://shadcnblocks.com?utm_source=tweakcn&utm_medium=theme-editor-preview"
@@ -191,41 +183,37 @@ const ThemePreviewPanel = ({ styles, currentMode }: ThemeEditorPreviewProps) => 
                       </Button>
                     </Link>
                   </div>
-                  <DemoPricing />
+                  <ScrollArea className="size-full">
+                    <DemoPricing />
+                  </ScrollArea>
                 </ExamplesPreviewContainer>
               </TabsContent>
 
-              <TabsContent value="mail" className="@container mt-0 h-full space-y-6">
-                <ExamplesPreviewContainer className="min-w-[1300px]">
-                  <DemoMail />
+              <TabsContent value="mail" className="@container m-0 size-full">
+                <ExamplesPreviewContainer className="size-full">
+                  <ScrollArea className="size-full">
+                    <DemoMail />
+                  </ScrollArea>
                 </ExamplesPreviewContainer>
               </TabsContent>
 
-              <TabsContent value="tasks" className="@container mt-0 h-full space-y-6">
-                <ExamplesPreviewContainer className="min-w-[1300px]">
-                  <DemoTasks />
+              <TabsContent value="typography" className="m-0 size-full">
+                <ExamplesPreviewContainer className="size-full">
+                  <ScrollArea className="size-full">
+                    <TypographyDemo />
+                  </ScrollArea>
                 </ExamplesPreviewContainer>
               </TabsContent>
 
-              <TabsContent value="music" className="@container mt-0 h-full space-y-6">
-                <ExamplesPreviewContainer className="min-w-[1300px]">
-                  <DemoMusic />
-                </ExamplesPreviewContainer>
+              <TabsContent value="colors" className="m-0 size-full">
+                <ScrollArea className="size-full">
+                  <div className="p-4">
+                    <ColorPreview styles={styles} currentMode={currentMode} />
+                  </div>
+                </ScrollArea>
               </TabsContent>
-
-              <TabsContent value="typography" className="space-y-6 p-4">
-                <ExamplesPreviewContainer>
-                  <TypographyDemo />
-                </ExamplesPreviewContainer>
-              </TabsContent>
-
-              <TabsContent value="colors" className="space-y-6 p-4">
-                <ColorPreview styles={styles} currentMode={currentMode} />
-              </TabsContent>
-
-              <ScrollBar orientation="horizontal" />
             </div>
-          </ScrollArea>
+          </section>
         </Tabs>
       </div>
 

--- a/components/editor/theme-preview/color-preview.tsx
+++ b/components/editor/theme-preview/color-preview.tsx
@@ -26,7 +26,7 @@ function ColorPreviewItem({ label, color, name }: { label: string; color: string
       </div>
 
       <div className="hidden flex-col opacity-0 transition-opacity group-hover/color-preview:opacity-100 md:flex">
-        <TooltipWrapper label="Edit color">
+        <TooltipWrapper label="Edit color" asChild>
           <Button
             variant="ghost"
             size="icon"

--- a/components/editor/theme-preview/color-preview.tsx
+++ b/components/editor/theme-preview/color-preview.tsx
@@ -1,4 +1,5 @@
 import { CopyButton } from "@/components/copy-button";
+import { TooltipWrapper } from "@/components/tooltip-wrapper";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { FocusColorId, useColorControlFocus } from "@/store/color-control-focus-store";
@@ -14,25 +15,28 @@ function ColorPreviewItem({ label, color, name }: { label: string; color: string
   const { focusColor } = useColorControlFocus();
 
   return (
-    <div className="group/color-preview hover:bg-muted relative flex items-center gap-4 rounded-md transition-colors">
-      <div className="h-12 w-12 rounded-md border" style={{ backgroundColor: color }} />
-      <div className="flex-1">
-        <p className="text-sm font-medium @max-3xl:text-xs">{label}</p>
-        <p className="text-muted-foreground text-xs">{color}</p>
+    <div className="group/color-preview hover:bg-muted/60 relative flex items-center gap-2 rounded-md p-1 transition-colors">
+      <div
+        className="size-14 shrink-0 rounded-md border @max-3xl:size-12"
+        style={{ backgroundColor: color }}
+      />
+      <div className="flex-1 space-y-1 overflow-hidden">
+        <p className="line-clamp-2 text-sm leading-tight font-medium @max-3xl:text-xs">{label}</p>
+        <p className="text-muted-foreground truncate font-mono text-xs">{color}</p>
       </div>
 
-      <div className="absolute right-6 hidden rounded-md opacity-0 transition-opacity group-hover/color-preview:opacity-100 md:block">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => focusColor(name as FocusColorId)}
-          className="size-6 [&>svg]:size-3.5"
-        >
-          <SquarePen />
-        </Button>
-      </div>
-      <div className="absolute right-1 rounded-md opacity-0 transition-opacity group-hover/color-preview:opacity-100">
-        <CopyButton textToCopy={color} />
+      <div className="hidden flex-col opacity-0 transition-opacity group-hover/color-preview:opacity-100 md:flex">
+        <TooltipWrapper label="Edit color">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => focusColor(name as FocusColorId)}
+            className="size-7 @max-3xl:size-6 [&>svg]:size-3.5"
+          >
+            <SquarePen />
+          </Button>
+        </TooltipWrapper>
+        <CopyButton textToCopy={color} className="size-7 @max-3xl:size-6" />
       </div>
     </div>
   );
@@ -46,9 +50,9 @@ const ColorPreview = ({ styles, currentMode }: ColorPreviewProps) => {
   return (
     <div className="@container grid grid-cols-1 gap-4 md:gap-8">
       {/* Primary Colors */}
-      <div className="space-y-4">
-        <h3 className="text-muted-foreground pb-2 text-sm font-semibold">Primary Theme Colors</h3>
-        <div className="@6xl grid grid-cols-1 gap-4 @sm:grid-cols-2 @2xl:grid-cols-3 @4xl:grid-cols-4">
+      <div className="space-y-4 @max-3xl:space-y-2">
+        <h3 className="text-muted-foreground text-sm font-semibold">Primary Theme Colors</h3>
+        <div className="@6xl grid grid-cols-1 gap-2 @sm:grid-cols-2 @2xl:grid-cols-3 @4xl:grid-cols-4">
           <ColorPreviewItem
             label="Background"
             color={styles[currentMode].background}
@@ -71,10 +75,8 @@ const ColorPreview = ({ styles, currentMode }: ColorPreviewProps) => {
       <Separator />
 
       {/* Secondary & Accent Colors */}
-      <div className="space-y-4">
-        <h3 className="text-muted-foreground pb-2 text-sm font-semibold">
-          Secondary & Accent Colors
-        </h3>
+      <div className="space-y-4 @max-3xl:space-y-2">
+        <h3 className="text-muted-foreground text-sm font-semibold">Secondary & Accent Colors</h3>
         <div className="@6xl grid grid-cols-1 gap-4 @sm:grid-cols-2 @2xl:grid-cols-3 @4xl:grid-cols-4">
           <ColorPreviewItem
             label="Secondary"
@@ -98,8 +100,8 @@ const ColorPreview = ({ styles, currentMode }: ColorPreviewProps) => {
       <Separator />
 
       {/* UI Component Colors */}
-      <div className="space-y-4">
-        <h3 className="text-muted-foreground pb-2 text-sm font-semibold">UI Component Colors</h3>
+      <div className="space-y-4 @max-3xl:space-y-2">
+        <h3 className="text-muted-foreground text-sm font-semibold">UI Component Colors</h3>
         <div className="grid grid-cols-1 gap-4 @sm:grid-cols-2 @2xl:grid-cols-3 @4xl:grid-cols-4">
           <ColorPreviewItem label="Card" color={styles[currentMode].card} name="card" />
           <ColorPreviewItem
@@ -125,23 +127,20 @@ const ColorPreview = ({ styles, currentMode }: ColorPreviewProps) => {
       <Separator />
 
       {/* Utility & Form Colors */}
-      <div className="space-y-4">
-        <h3 className="text-muted-foreground pb-2 text-sm font-semibold">Utility & Form Colors</h3>
+      <div className="space-y-4 @max-3xl:space-y-2">
+        <h3 className="text-muted-foreground text-sm font-semibold">Utility & Form Colors</h3>
         <div className="grid grid-cols-1 gap-4 @sm:grid-cols-2 @2xl:grid-cols-3 @4xl:grid-cols-4">
           <ColorPreviewItem label="Border" color={styles[currentMode].border} name="border" />
           <ColorPreviewItem label="Input" color={styles[currentMode].input} name="input" />
           <ColorPreviewItem label="Ring" color={styles[currentMode].ring} name="ring" />
-          <ColorPreviewItem label="Radius" color={styles[currentMode].radius} name="radius" />
         </div>
       </div>
 
       <Separator />
 
       {/* Status & Feedback Colors */}
-      <div className="space-y-4">
-        <h3 className="text-muted-foreground pb-2 text-sm font-semibold">
-          Status & Feedback Colors
-        </h3>
+      <div className="space-y-4 @max-3xl:space-y-2">
+        <h3 className="text-muted-foreground text-sm font-semibold">Status & Feedback Colors</h3>
         <div className="grid grid-cols-1 gap-4 @sm:grid-cols-2 @2xl:grid-cols-3 @4xl:grid-cols-4">
           <ColorPreviewItem
             label="Destructive"
@@ -159,8 +158,8 @@ const ColorPreview = ({ styles, currentMode }: ColorPreviewProps) => {
       <Separator />
 
       {/* Chart & Data Visualization Colors */}
-      <div className="space-y-4">
-        <h3 className="text-muted-foreground pb-2 text-sm font-semibold">
+      <div className="space-y-4 @max-3xl:space-y-2">
+        <h3 className="text-muted-foreground text-sm font-semibold">
           Chart & Visualization Colors
         </h3>
         <div className="grid grid-cols-1 gap-4 @sm:grid-cols-2 @2xl:grid-cols-3 @4xl:grid-cols-4">
@@ -175,10 +174,8 @@ const ColorPreview = ({ styles, currentMode }: ColorPreviewProps) => {
       <Separator />
 
       {/* Sidebar Colors */}
-      <div className="space-y-4">
-        <h3 className="text-muted-foreground pb-2 text-sm font-semibold">
-          Sidebar & Navigation Colors
-        </h3>
+      <div className="space-y-4 @max-3xl:space-y-2">
+        <h3 className="text-muted-foreground text-sm font-semibold">Sidebar & Navigation Colors</h3>
         <div className="grid grid-cols-1 gap-4 @sm:grid-cols-2 @2xl:grid-cols-3 @4xl:grid-cols-4">
           <ColorPreviewItem
             label="Sidebar Background"

--- a/components/editor/theme-preview/tabs-trigger-pill.tsx
+++ b/components/editor/theme-preview/tabs-trigger-pill.tsx
@@ -1,8 +1,12 @@
 import { TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
-import { TabsTriggerProps } from "@radix-ui/react-tabs";
+import * as React from "react";
 
-const TabsTriggerPill = ({ children, className, ...props }: TabsTriggerProps) => {
+const TabsTriggerPill = ({
+  children,
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TabsTrigger>) => {
   return (
     <TabsTrigger
       className={cn(

--- a/components/examples/cards/stats.tsx
+++ b/components/examples/cards/stats.tsx
@@ -84,7 +84,7 @@ export function CardsStats() {
           </ChartContainer>
         </CardContent>
       </Card>
-      <Card className="relative flex flex-col pb-0 @5xl:hidden @7xl:flex">
+      <Card className="relative flex flex-col overflow-hidden pb-0 @5xl:hidden @7xl:flex">
         <CardHeader>
           <CardDescription>Subscriptions</CardDescription>
           <CardTitle className="text-3xl">+2,350</CardTitle>

--- a/components/examples/dashboard/index.tsx
+++ b/components/examples/dashboard/index.tsx
@@ -1,15 +1,17 @@
+"use client";
+
 import { AppSidebar } from "@/components/examples/dashboard/components/app-sidebar";
 import { ChartAreaInteractive } from "@/components/examples/dashboard/components/chart-area-interactive";
 import { DataTable } from "@/components/examples/dashboard/components/data-table";
 import { SectionCards } from "@/components/examples/dashboard/components/section-cards";
 import { SiteHeader } from "@/components/examples/dashboard/components/site-header";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
-import { ChartPieDonut } from "./components/chart-pie-donut";
 import { ChartBarMixed } from "./components/chart-bar-mixed";
+import { ChartPieDonut } from "./components/chart-pie-donut";
 
 import data from "./data.json";
 
-export default function Page() {
+export default function Dashboard() {
   return (
     <SidebarProvider>
       <AppSidebar variant="inset" />

--- a/components/examples/pricing/pricing.tsx
+++ b/components/examples/pricing/pricing.tsx
@@ -73,17 +73,22 @@ const Pricing2 = ({
 }: Pricing2Props) => {
   const [isYearly, setIsYearly] = useState(false);
   return (
-    <section className="py-16">
+    <section className="@container py-16">
       <div className="container mx-auto">
-        <div className="mx-auto flex max-w-5xl flex-col items-center gap-6 text-center">
-          <h2 className="text-foreground text-4xl font-bold text-pretty lg:text-6xl">{heading}</h2>
-          <p className="text-muted-foreground lg:text-xl">{description}</p>
-          <div className="text-foreground flex items-center gap-3 text-lg">
-            Monthly
-            <Switch checked={isYearly} onCheckedChange={() => setIsYearly(!isYearly)} />
-            Yearly
+        <div className="mx-auto flex max-w-5xl flex-col items-center gap-8 text-center">
+          <div className="flex size-full flex-col items-center gap-4">
+            <h2 className="text-foreground text-3xl leading-tight font-bold tracking-tight text-pretty @3xl:text-5xl">
+              {heading}
+            </h2>
+            <p className="text-muted-foreground @3xl:text-xl">{description}</p>
+            <div className="text-foreground flex items-center gap-3 text-lg">
+              Monthly
+              <Switch checked={isYearly} onCheckedChange={() => setIsYearly(!isYearly)} />
+              Yearly
+            </div>
           </div>
-          <div className="flex flex-col items-stretch gap-6 md:flex-row">
+
+          <div className="flex flex-col items-stretch gap-6 @3xl:flex-row">
             {plans.map((plan) => (
               <Card key={plan.id} className="flex w-80 flex-col justify-between text-left">
                 <CardHeader>

--- a/components/examples/typography/typography-demo.tsx
+++ b/components/examples/typography/typography-demo.tsx
@@ -3,8 +3,8 @@ import { DemoFontShowcase } from "./font-showcase";
 
 export default function TypographyDemo() {
   return (
-    <div className="@container relative grid grid-cols-9 gap-4">
-      <div className="sticky top-6 hidden size-full max-h-140 overflow-hidden lg:col-span-3 lg:block">
+    <div className="@container relative grid grid-cols-9 gap-4 p-4">
+      <div className="sticky top-4 hidden size-full max-h-140 overflow-hidden lg:col-span-3 lg:block">
         <DemoFontShowcase />
       </div>
       <div className="col-span-9 lg:col-span-6">


### PR DESCRIPTION
I've decided to make these changes in order to improve the Preview Panel experience and make it easier to add new blocks/demo components.

## Changes:
* Each TabContent now has it's ScrollArea only for the demos that make sense.
* Improved the Resposiviness of the Color Palette and the Pricing Demo
* Removed Tasks and Movies demos since they're not compelling examples to showcase the theme styles.

### What's next?
* Change the existing Dashboard component for a New one that better showcases the styles.
* (To be defined) Remove the Pricing Demo since it might be confusing for the user now that tweakcn has its own Pricing page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced browser support for light and dark color schemes, improving native UI consistency.

* **Refactor**
  * Unified tab content layout and scrolling in the theme preview panel.
  * Removed unused preview tabs and corresponding menu items for a cleaner interface.
  * Renamed the dashboard example’s main component for clarity.
  * Simplified tooltip integration and improved styling management in the theme toggle component.
  * Updated type annotations for improved clarity in tab trigger pill component.

* **Style**
  * Improved layout, spacing, and responsiveness in color preview and pricing components.
  * Enhanced tooltip and button interactions in the color preview section.
  * Adjusted padding and sticky sidebar positioning in typography demo.
  * Ensured content does not overflow in stats card example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->