### PR TITLE
fix: add speed dependency to animation frame in MarqueeRow

### DIFF
--- a/components/home/testimonials.tsx
+++ b/components/home/testimonials.tsx
@@ -157,7 +157,7 @@ const MarqueeRow = ({
 
     animationFrame.current = requestAnimationFrame(animate);
     return () => cancelAnimationFrame(animationFrame.current);
-  }, [containerWidth, reverse, shouldReduceMotion]);
+  }, [containerWidth, reverse, shouldReduceMotion, speed]);
 
   const pause = () => (isPaused.current = true);
   const resume = () => {


### PR DESCRIPTION
## What ? 

This PR adds the missing speed dependency in the useEffect hence clearing up linting issues 

<img width="950" height="263" alt="image" src="https://github.com/user-attachments/assets/2512c5eb-653e-4ceb-bd20-b732158fba0e" />
