### PR TITLE
Add Opt-in to exported CSS Vars and clean generated CSS code

### DIFF
--- a/store/preferences-store.ts
+++ b/store/preferences-store.ts
@@ -1,6 +1,6 @@
+import { ColorFormat } from "@/types";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { ColorFormat } from "@/types";
 
 type PackageManager = "pnpm" | "npm" | "yarn" | "bun";
 export type ColorSelectorTab = "list" | "palette";
@@ -13,11 +13,13 @@ const colorFormatsByVersion = {
 interface PreferencesStore {
   tailwindVersion: "3" | "4";
   colorFormat: ColorFormat;
+  includeFontVariables: boolean;
   packageManager: PackageManager;
   colorSelectorTab: ColorSelectorTab;
   chatSuggestionsOpen: boolean;
   setTailwindVersion: (version: "3" | "4") => void;
   setColorFormat: (format: ColorFormat) => void;
+  setIncludeFontVariables: (includeFontVars: boolean) => void;
   setPackageManager: (pm: PackageManager) => void;
   setColorSelectorTab: (tab: ColorSelectorTab) => void;
   setChatSuggestionsOpen: (open: boolean) => void;
@@ -29,6 +31,7 @@ export const usePreferencesStore = create<PreferencesStore>()(
     (set, get) => ({
       tailwindVersion: "4",
       colorFormat: "oklch",
+      includeFontVariables: true,
       packageManager: "pnpm",
       colorSelectorTab: "list",
       chatSuggestionsOpen: true,
@@ -45,6 +48,9 @@ export const usePreferencesStore = create<PreferencesStore>()(
         if (availableFormats.includes(format)) {
           set({ colorFormat: format });
         }
+      },
+      setIncludeFontVariables: (includeFontVars: boolean) => {
+        set({ includeFontVariables: includeFontVars });
       },
       setPackageManager: (pm: PackageManager) => {
         set({ packageManager: pm });


### PR DESCRIPTION
## Additions:
* User can now choose if they wanna export the Font Variables in the generated CSS code.
* Cleaned up the generated CSS code for the selectors. Some properties do not need to be overriden (e.g. font vars and radius)

https://github.com/user-attachments/assets/7a3c509c-c475-45b9-8a24-f3fee7e8fe8f

These are the diffs in code for `:root`, `.dark` and `@theme inline`. 
Same theme, but with vars cleaned up.

<img width="2202" height="1283" alt="image" src="https://github.com/user-attachments/assets/f9876825-1518-4f08-89c4-b357afc3b76f" />
<img width="2229" height="1194" alt="image" src="https://github.com/user-attachments/assets/f32d7777-16c6-44f5-ba4a-127dcf7a350a" />
<img width="2248" height="544" alt="image" src="https://github.com/user-attachments/assets/cc8eb9c7-9768-4450-86b8-faf62dc8bbbd" />
