### PR TITLE
Support for Google Fonts in Preview script and Error Feedback

### DIFF
--- a/public/live-preview-embed-script.js
+++ b/public/live-preview-embed-script.js
@@ -143,6 +143,7 @@ const TWEAKCN_MESSAGE = {
   THEME_UPDATE: "TWEAKCN_THEME_UPDATE",
   THEME_APPLIED: "TWEAKCN_THEME_APPLIED",
   EMBED_LOADED: "TWEAKCN_EMBED_LOADED",
+  EMBED_ERROR: "TWEAKCN_EMBED_ERROR",
 };
 
 // ----- MAIN SCRIPT -----
@@ -157,9 +158,13 @@ const TWEAKCN_MESSAGE = {
     if (event.source !== window.parent) return;
     // Verify the message has the expected structure
     if (!event.data || typeof event.data.type !== "string") return;
-    // TODO: Once it's live, verify the origin of the message for security
-    // const allowedOrigin = 'https://tweakcn.com';
-    // if (event.origin !== allowedOrigin) return;    
+
+    // TODO: Remove localhost once this is live
+    const ALLOWED_ORIGINS = ['https://tweakcn.com', 'http://localhost:3000'];
+    if (!ALLOWED_ORIGINS.includes(event.origin)){
+      sendMessageToParent({ type: TWEAKCN_MESSAGE.EMBED_ERROR, payload: { error: "Origin not allowed. Preview failed to establish the connection with tweakcn." } });
+      return;
+    } ;    
     
     const { type, payload } = event.data;
 

--- a/types/live-preview-embed.ts
+++ b/types/live-preview-embed.ts
@@ -9,6 +9,7 @@ export const MESSAGE = {
   THEME_UPDATE: "TWEAKCN_THEME_UPDATE",
   THEME_APPLIED: "TWEAKCN_THEME_APPLIED",
   EMBED_LOADED: "TWEAKCN_EMBED_LOADED",
+  EMBED_ERROR: "TWEAKCN_EMBED_ERROR",
 } as const;
 
 export type MessageType = (typeof MESSAGE)[keyof typeof MESSAGE];
@@ -28,7 +29,8 @@ export type EmbedMessage =
   | { type: typeof MESSAGE.SHADCN_STATUS; payload: ShadcnStatusPayload }
   | { type: typeof MESSAGE.THEME_UPDATE; payload: ThemeUpdatePayload }
   | { type: typeof MESSAGE.THEME_APPLIED }
-  | { type: typeof MESSAGE.EMBED_LOADED };
+  | { type: typeof MESSAGE.EMBED_LOADED }
+  | { type: typeof MESSAGE.EMBED_ERROR; payload: { error: string } };
 
 export type IframeStatus =
   | "unknown"
@@ -36,4 +38,5 @@ export type IframeStatus =
   | "connected"
   | "supported"
   | "unsupported"
-  | "missing";
+  | "missing"
+  | "error";


### PR DESCRIPTION
## Additions:
* The Live Theme Preview embed script now loads fonts from the Google Font API, fonts will be part of the Preview as long as the Preview Website source code has `--font-sans`, `--font-serif` and `--font-mono` variables.
* The theme injection hook stores an error message to display in the UI and help the user solve the issue.

<img width="1509" height="1127" alt="image" src="https://github.com/user-attachments/assets/161030a8-9675-4459-9c77-0b6c7578a274" />
<img width="1501" height="1131" alt="image" src="https://github.com/user-attachments/assets/bc67a3fd-5884-4126-9830-24712e6a1b9b" />
