### PR TITLE
fix: css variable parsing

### DIFF
--- a/utils/parse-css-input.ts
+++ b/utils/parse-css-input.ts
@@ -52,6 +52,12 @@ const parseColorVariables = (
         return;
       }
 
+      // Skip CSS variable references (var(...)) as they can't be processed as colors
+      if (value.trim().startsWith("var(") && value.trim().endsWith(")")) {
+        console.warn(`Skipping CSS variable reference: ${cleanName}: ${value}`);
+        return;
+      }
+
       const colorValue = processColorValue(value);
       const formattedValue = colorFormatter(colorValue, "hex");
       target[cleanName as keyof ThemeStyleProps] = formattedValue;


### PR DESCRIPTION
This pull request introduces an improvement to the `parseColorVariables` function in `utils/parse-css-input.ts` to handle CSS variable references more robustly. The main change is the addition of logic to skip CSS variable references (e.g., `var(--color-primary)`) during color parsing, preventing errors and ensuring only actual color values are processed.

Color variable parsing improvements:

* Updated `parseColorVariables` to detect and skip CSS variable references (`var(...)`), logging a warning when encountered, so only valid color values are processed.

<img width="1647" height="1021" alt="image" src="https://github.com/user-attachments/assets/dfb50323-2de1-4943-b3f0-dc569c975712" />
