### PR TITLE
Optimize AI costs by reducing the context window

### DIFF
--- a/components/editor/ai/chat-interface.tsx
+++ b/components/editor/ai/chat-interface.tsx
@@ -5,14 +5,13 @@ import { useChatContext } from "@/hooks/use-chat-context";
 import { useGuards } from "@/hooks/use-guards";
 import { usePostLoginAction } from "@/hooks/use-post-login-action";
 import { toast } from "@/hooks/use-toast";
-import { MAX_MESSAGES_WINDOW } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 import { AIPromptData } from "@/types/ai";
-import { BrainCircuit } from "lucide-react";
 import dynamic from "next/dynamic";
 import React from "react";
 import { ChatInput } from "./chat-input";
 import { ClosableSuggestedPillActions } from "./closeable-suggested-pill-actions";
+import { ContextLimitReachedAlert } from "./context-limit-reached-alert";
 
 const Messages = dynamic(() => import("./messages").then((mod) => mod.Messages), {
   ssr: false,
@@ -96,18 +95,7 @@ export function ChatInterface() {
 
   return (
     <section className="@container relative isolate z-1 mx-auto flex size-full max-w-[49rem] flex-1 flex-col justify-center">
-      {messages.length >= MAX_MESSAGES_WINDOW && (
-        <div className="bg-muted flex flex-col gap-0.5 border-y px-4 py-2">
-          <p className="flex items-center gap-1 text-sm font-medium">
-            <BrainCircuit className="size-3.5" />
-            Context window limited
-          </p>
-          <p className="text-muted-foreground text-xs text-pretty">
-            Only the last 10 messages are sent to the model. For a fresh context window, consider
-            starting a new chat.
-          </p>
-        </div>
-      )}
+      <ContextLimitReachedAlert messageCount={messages.length} />
 
       <div
         className={cn(

--- a/components/editor/ai/chat-interface.tsx
+++ b/components/editor/ai/chat-interface.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useChatContext } from "@/hooks/use-chat-context";
 import { useAIThemeGenerationCore } from "@/hooks/use-ai-theme-generation-core";
+import { useChatContext } from "@/hooks/use-chat-context";
 import { useGuards } from "@/hooks/use-guards";
 import { usePostLoginAction } from "@/hooks/use-post-login-action";
 import { toast } from "@/hooks/use-toast";
+import { MAX_MESSAGES_WINDOW } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 import { AIPromptData } from "@/types/ai";
+import { BrainCircuit } from "lucide-react";
 import dynamic from "next/dynamic";
 import React from "react";
 import { ChatInput } from "./chat-input";
@@ -94,6 +96,19 @@ export function ChatInterface() {
 
   return (
     <section className="@container relative isolate z-1 mx-auto flex size-full max-w-[49rem] flex-1 flex-col justify-center">
+      {messages.length >= MAX_MESSAGES_WINDOW && (
+        <div className="bg-muted flex flex-col gap-0.5 border-y px-4 py-2">
+          <p className="flex items-center gap-1 text-sm font-medium">
+            <BrainCircuit className="size-3.5" />
+            Context window limited
+          </p>
+          <p className="text-muted-foreground text-xs text-pretty">
+            Only the last 10 messages are sent to the model. For a fresh context window, consider
+            starting a new chat.
+          </p>
+        </div>
+      )}
+
       <div
         className={cn(
           "relative flex size-full flex-1 flex-col overflow-hidden transition-all duration-300 ease-out"

--- a/components/editor/ai/context-limit-reached-alert.tsx
+++ b/components/editor/ai/context-limit-reached-alert.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { TooltipWrapper } from "@/components/tooltip-wrapper";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useChatContext } from "@/hooks/use-chat-context";
+import { MAX_MESSAGES_WINDOW } from "@/lib/constants";
+import { cn } from "@/lib/utils";
+import { AlertCircle, BrainCircuit, MoreVertical, Plus, X } from "lucide-react";
+import * as React from "react";
+
+type ContextLimitReachedAlertProps = {
+  messageCount: number;
+};
+
+export function ContextLimitReachedAlert({ messageCount }: ContextLimitReachedAlertProps) {
+  const shouldShow = messageCount >= MAX_MESSAGES_WINDOW;
+  const [isMinimized, setIsMinimized] = React.useState(false);
+  const { startNewChat } = useChatContext();
+
+  if (!shouldShow) return null;
+
+  if (isMinimized) {
+    return (
+      <div className="animate-in zoom-in-75 absolute top-0 z-100 px-4" key="minimized-alert">
+        <Button
+          variant="outline"
+          onClick={() => setIsMinimized(false)}
+          size="icon"
+          className="relative size-8"
+        >
+          <BrainCircuit className="size-4" />
+
+          <div className="bg-destructive absolute top-1 right-1 size-1.5 animate-bounce rounded-full" />
+        </Button>
+      </div>
+    );
+  }
+
+  // Full alert banner centered at the top
+  return (
+    <div
+      key="expanded-alert"
+      className={cn("fade-in-100 pointer-events-auto absolute top-0 z-100 w-full px-4")}
+    >
+      <div
+        className={cn(
+          "relative flex w-full items-start gap-2 rounded-md border p-3 shadow-sm",
+          "bg-muted/90 supports-[backdrop-filter]:bg-muted/80 backdrop-blur"
+        )}
+      >
+        <AlertCircle className="mt-0.5 size-3.5 shrink-0" />
+        <div className="min-w-0 flex-1">
+          <p className="flex items-center gap-1 text-sm font-medium">Context limit reached</p>
+          <p className="text-muted-foreground mt-0.5 text-xs">
+            The context window is limited to the last{" "}
+            <span className="font-medium">{MAX_MESSAGES_WINDOW}</span> messages. Consider starting a
+            new chat.
+          </p>
+        </div>
+        <div className="flex items-center gap-1">
+          <DropdownMenu>
+            <TooltipWrapper label="Actions" asChild>
+              <DropdownMenuTrigger asChild>
+                <Button size="icon" variant="ghost" className={cn("size-6")}>
+                  <MoreVertical className="size-3.5!" />
+                </Button>
+              </DropdownMenuTrigger>
+            </TooltipWrapper>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onSelect={() => {
+                  startNewChat();
+                  setIsMinimized(false);
+                }}
+                className="cursor-pointer text-sm"
+              >
+                <Plus />
+                Start new chat
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <TooltipWrapper label="Dismiss" asChild>
+            <Button
+              onClick={() => setIsMinimized(true)}
+              size="icon"
+              variant="ghost"
+              className={cn("size-6")}
+            >
+              <X className="size-3.5!" />
+            </Button>
+          </TooltipWrapper>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -18,8 +18,8 @@ export const baseProviderOptions = {
 
 export const myProvider = customProvider({
   languageModels: {
-    base: google("gemini-2.5-flash"),
-    "theme-generation": google("gemini-2.5-flash"),
+    base: google("gemini-2.5-pro"),
+    "theme-generation": google("gemini-2.5-pro"),
     "prompt-enhancement": google("gemini-2.5-flash"),
   },
 });

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -7,5 +7,6 @@ export const AI_REQUEST_FREE_TIER_LIMIT = 5;
 export const MAX_IMAGE_FILES = 2;
 export const MAX_IMAGE_FILE_SIZE = 4 * 1024 * 1024; // 4MB
 export const MAX_SVG_FILE_SIZE = 1 * 1024 * 1024; // 1MB
+export const MAX_MESSAGES_WINDOW = 10;
 
 export const MAX_FREE_THEMES = 10;


### PR DESCRIPTION
This PR might not solve the main issue, but it's a proposal.
Basically the LLM is fed with the last 10 messages, and only the last assistant message that generated a theme has the `themeStyles ` attached to reduce the size of the payload sent. Because right now it grows exponentially.

DISCLAIMER: I'm not sure how removing the attached themeStyled of the previosly generated themes in the whole conversation will affect the results, i want to believe it should be enough with sending (1) the user messages, with @ and everything like before, (2) the assissant messages text responsed (the announcement of the changes that will be made and the changes that were actually made) and (3) the LAST generated theme  from the conversation attached.