### PR TITLE
Fix: Update Outline Badge to use text-inherit for proper Dark Mode visibility (#67)

### DIFF
--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -14,7 +14,7 @@ const badgeVariants = cva(
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
-        outline: "text-foreground",
+        outline: "text-inherit",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
**Fixes #67**

This PR resolves an issue where the **Outline Badge** becomes unreadable in **Dark mode** across multiple themes, including the **Notebook** theme. When hovering over a mail item, the badge’s text color matched the hover foreground color, resulting in nearly invisible text.

### **Root Cause**

The `outline` variant in the `Badge` component applied a fixed `text-foreground` class, which prevented it from inheriting the parent component’s text color during hover states. In dark mode, this caused the badge’s text to blend into the background.

### **What I changed**

* Replaced the `outline` variant’s explicit `text-foreground` class with `text-inherit`.
* Allowed the badge to inherit color styles from its parent, aligning its hover behavior with the rest of the MailList UI.

### **Why this fix works**

By allowing the badge to inherit its parent’s text color:

* It maintains proper contrast in Dark mode.
* Adapts to the parent component’s hover text color.
* Behaves consistently across themes, matching the UI’s global styling logic.

### **Testing**

* Verified that Outline Badges remain readable in Dark mode.
* Confirmed that badge text updates correctly on hover within the MailList component.
* Checked for regressions in Light mode and other themes — none observed.

<img width="1407" height="579" alt="image" src="https://github.com/user-attachments/assets/542cdcff-a96c-445b-89da-ec3d0fe9f7ce" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text color styling in outline badge variant.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->