### PR TITLE
fix(color): Preserve alpha/opacity in color formatting

### DIFF
--- a/utils/color-converter.ts
+++ b/utils/color-converter.ts
@@ -3,12 +3,24 @@ import { ColorFormat } from "../types";
 import { Hsl } from "culori";
 
 export const formatNumber = (num?: number) => {
-  if (!num) return "0";
-  return num % 1 === 0 ? num : num.toFixed(4);
+  if (num === undefined || num === null) return "0";
+  if (num === 0) return "0";
+  return num % 1 === 0 ? String(num) : num.toFixed(4);
+};
+
+const hasAlpha = (color: { alpha?: number }): boolean => {
+  return color.alpha !== undefined && color.alpha < 1;
 };
 
 export const formatHsl = (hsl: Hsl) => {
-  return `hsl(${formatNumber(hsl.h)} ${formatNumber(hsl.s * 100)}% ${formatNumber(hsl.l * 100)}%)`;
+  const h = formatNumber(hsl.h);
+  const s = formatNumber(hsl.s * 100);
+  const l = formatNumber(hsl.l * 100);
+
+  if (hasAlpha(hsl)) {
+    return `hsl(${h} ${s}% ${l}% / ${formatNumber(hsl.alpha)})`;
+  }
+  return `hsl(${h} ${s}% ${l}%)`;
 };
 
 export const colorFormatter = (
@@ -26,15 +38,28 @@ export const colorFormatter = (
         if (tailwindVersion === "4") {
           return formatHsl(hsl);
         }
-        return `${formatNumber(hsl.h)} ${formatNumber(hsl.s * 100)}% ${formatNumber(hsl.l * 100)}%`;
+        const base = `${formatNumber(hsl.h)} ${formatNumber(hsl.s * 100)}% ${formatNumber(hsl.l * 100)}%`;
+        if (hasAlpha(hsl)) {
+          return `${base} / ${formatNumber(hsl.alpha)}`;
+        }
+        return base;
       }
       case "rgb":
         return culori.formatRgb(color); // e.g., "rgb(64, 128, 192)"
       case "oklch": {
         const oklch = culori.converter("oklch")(color);
-        return `oklch(${formatNumber(oklch.l)} ${formatNumber(oklch.c)} ${formatNumber(oklch.h)})`;
+        const l = formatNumber(oklch.l);
+        const c = formatNumber(oklch.c);
+        const h = formatNumber(oklch.h);
+        if (hasAlpha(oklch)) {
+          return `oklch(${l} ${c} ${h} / ${formatNumber(oklch.alpha)})`;
+        }
+        return `oklch(${l} ${c} ${h})`;
       }
       case "hex":
+        if (hasAlpha(color)) {
+          return culori.formatHex8(color); // e.g., "#4080c0ff"
+        }
         return culori.formatHex(color); // e.g., "#4080c0"
       default:
         return colorValue;


### PR DESCRIPTION
Fixes #246

  This PR fixes the issue where oklch colors with percentage-based opacity (e.g., oklch(1 0 0 / 10%)) were rendering at full opacity in previews instead of respecting the transparency value.

  Problem

  When users input oklch colors with alpha/opacity values, the color picker correctly displayed the color, but the preview rendered it at full opacity. This occurred because the colorFormatter function was stripping the alpha channel when converting colors.

  Solution

  Updated /utils/color-converter.ts to preserve alpha values across all color format outputs:

  - Added hasAlpha helper function to detect colors with transparency (alpha < 1)
  - Updated formatHsl to include alpha channel when present: hsl(h s% l% / alpha)
  - Updated colorFormatter oklch case to preserve alpha: oklch(l c h / alpha)
  - Updated colorFormatter hsl case (both Tailwind v3 and v4 formats) to preserve alpha
  - Updated colorFormatter hex case to use 8-digit hex (formatHex8) when alpha is present

  Changes

  | Format   | Before          | After (with alpha)    |
  |----------|-----------------|-----------------------|
  | oklch    | oklch(1 0 0)    | oklch(1 0 0 / 0.1)    |
  | hsl (v4) | hsl(0 100% 50%) | hsl(0 100% 50% / 0.1) |
  | hsl (v3) | 0 100% 50%      | 0 100% 50% / 0.1      |
  | hex      | #ff0000         | #ff00001a             |

  Backward Compatibility

  Colors without alpha (or with alpha = 1) continue to output in the same format as before, ensuring no breaking changes for existing themes.

  Test Plan

  - Input oklch(1 0 0 / 10%) in color picker → verify preview shows 10% opacity
  - Input hsl(0 100% 50% / 50%) → verify preview shows 50% opacity
  - Export theme CSS → verify alpha values are preserved in output
  - Verify existing colors without alpha still work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive transparency/alpha channel support across HSL, oklch, and hex color formats
  * Extended color formatting with modern CSS syntax for alpha values
  * Improved robustness in color value handling for edge cases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->