### PR TITLE
fix: resolve hydration issues in editor and root layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -53,7 +53,7 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <ThemeScript />
         <DynamicFontLoader />

--- a/components/editor/action-bar/components/undo-redo-buttons.tsx
+++ b/components/editor/action-bar/components/undo-redo-buttons.tsx
@@ -2,11 +2,17 @@ import { TooltipWrapper } from "@/components/tooltip-wrapper";
 import { Button } from "@/components/ui/button";
 import { useEditorStore } from "@/store/editor-store";
 import { Redo, Undo } from "lucide-react";
+import * as React from "react";
 
-interface UndoRedoButtonsProps extends React.ComponentProps<typeof Button> {}
+interface UndoRedoButtonsProps extends React.ComponentProps<typeof Button> { }
 
 export function UndoRedoButtons({ disabled, ...props }: UndoRedoButtonsProps) {
   const { undo, redo, canUndo, canRedo } = useEditorStore();
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
 
   return (
     <div className="flex items-center gap-1">
@@ -14,7 +20,7 @@ export function UndoRedoButtons({ disabled, ...props }: UndoRedoButtonsProps) {
         <Button
           variant="ghost"
           size="icon"
-          disabled={disabled || !canUndo()}
+          disabled={!mounted || disabled || !canUndo()}
           {...props}
           onClick={undo}
         >
@@ -26,7 +32,7 @@ export function UndoRedoButtons({ disabled, ...props }: UndoRedoButtonsProps) {
         <Button
           variant="ghost"
           size="icon"
-          disabled={disabled || !canRedo()}
+          disabled={!mounted || disabled || !canRedo()}
           {...props}
           onClick={redo}
         >


### PR DESCRIPTION
This PR addresses two hydration mismatch errors encountered during development and debugging.

1. Fix Root Layout Hydration Mismatch
The ThemeScript component injects inline styles (CSS variables) into the <html> tag at runtime to prevent FOUC (Flash of Unstyled Content). This caused a mismatch because the server-rendered <html> tag did not contain these styles, while the client-side tag did immediately after hydration.

2. Fix Editor Undo/Redo Buttons Hydration Mismatch
The  UndoRedoButtons component relies on useEditorStore which persists state to localStorage.

Server-side: Local storage is unavailable, so the undo/redo history is empty, rendering the buttons as disabled.
Client-side: The store hydrates from localStorage, restoring history and potentially rendering the buttons as enabled.
This difference caused a hydration error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved undo/redo button reliability during component initialization
  * Resolved hydration warnings in the root layout

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->