### PR TITLE
feat(editor): added floating theme editor

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { GetProDialogWrapper } from "@/components/get-pro-dialog-wrapper";
 import { PostHogInit } from "@/components/posthog-init";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ThemeScript } from "@/components/theme-script";
+import { ThemeEditorProvider } from "@/components/floating-theme-editor";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ChatProvider } from "@/hooks/use-chat-context";
@@ -87,7 +88,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   <AuthDialogWrapper />
                   <GetProDialogWrapper />
                   <Toaster />
-                  <ChatProvider>{children}</ChatProvider>
+                  <ChatProvider>
+                    <ThemeEditorProvider>{children}</ThemeEditorProvider>
+                  </ChatProvider>
                 </TooltipProvider>
               </ThemeProvider>
             </QueryProvider>

--- a/components/floating-theme-editor/floating-editor-header.tsx
+++ b/components/floating-theme-editor/floating-editor-header.tsx
@@ -1,0 +1,146 @@
+"use client";
+/**
+ * Header component for the floating theme editor
+ * Contains controls for inspector, minimize/maximize, and close
+ */
+
+import { TooltipWrapper } from "@/components/tooltip-wrapper";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+  ChevronDown,
+  ChevronUp,
+  GripVertical,
+  Inspect,
+  Maximize2,
+  Minimize2,
+  X,
+} from "lucide-react";
+import { PanelState } from "./use-floating-editor";
+
+interface FloatingEditorHeaderProps {
+  panelState: PanelState;
+  inspectorEnabled: boolean;
+  onInspectorToggle: () => void;
+  onPanelStateChange: (state: PanelState) => void;
+  onClose: () => void;
+}
+
+export function FloatingEditorHeader({
+  panelState,
+  inspectorEnabled,
+  onInspectorToggle,
+  onPanelStateChange,
+  onClose,
+}: FloatingEditorHeaderProps) {
+  const isDraggable = panelState !== "maximized";
+  const isCollapsed = panelState === "collapsed";
+
+  return (
+    <div
+      className="bg-muted/30 flex h-14 items-center justify-between border-b px-3"
+      onMouseDown={(e) => {
+        isDraggable
+          ? (e.currentTarget.style.cursor = "grabbing")
+          : (e.currentTarget.style.cursor = "default");
+      }}
+      onMouseUp={(e) => {
+        isDraggable
+          ? (e.currentTarget.style.cursor = "grab")
+          : (e.currentTarget.style.cursor = "default");
+      }}
+    >
+      <div className="flex items-center gap-2">
+        {isDraggable && (
+          <GripVertical
+            className="size-5 cursor-move"
+            onMouseDown={(e) => {
+              isDraggable
+                ? (e.currentTarget.style.cursor = "grabbing")
+                : (e.currentTarget.style.cursor = "default");
+            }}
+            onMouseUp={(e) => {
+              isDraggable
+                ? (e.currentTarget.style.cursor = "grab")
+                : (e.currentTarget.style.cursor = "default");
+            }}
+          />
+        )}
+        <span className="font-semibold">Theme Editor</span>
+      </div>
+
+      <div className="flex items-center gap-1">
+        {/* Inspector toggle button */}
+        <TooltipWrapper label="Toggle Inspector" asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onInspectorToggle}
+            className={cn(
+              "group size-8",
+              inspectorEnabled && "bg-accent text-accent-foreground w-auto"
+            )}
+          >
+            <Inspect className="size-4 transition-all group-hover:scale-120" />
+            {inspectorEnabled && <span className="text-xs tracking-wide uppercase">on</span>}
+          </Button>
+        </TooltipWrapper>
+
+        {/* Collapse button - shows when panel is normal or maximized */}
+        {panelState !== "collapsed" && (
+          <TooltipWrapper label="Collapse" asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onPanelStateChange("collapsed")}
+              className="group size-8"
+            >
+              <ChevronDown className="size-4 transition-all group-hover:scale-120" />
+            </Button>
+          </TooltipWrapper>
+        )}
+
+        {/* Expand button - shows when panel is collapsed */}
+        {panelState === "collapsed" && (
+          <TooltipWrapper label="Expand" asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onPanelStateChange("normal")}
+              className="group size-8"
+            >
+              <ChevronUp className="size-4 transition-all group-hover:scale-120" />
+            </Button>
+          </TooltipWrapper>
+        )}
+
+        {/* Maximize/Restore button - shows when not collapsed */}
+        {panelState !== "collapsed" && (
+          <TooltipWrapper label={panelState === "maximized" ? "Restore" : "Maximize"} asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                onPanelStateChange(panelState === "maximized" ? "normal" : "maximized")
+              }
+              className="group size-8"
+            >
+              {panelState === "maximized" ? (
+                <Minimize2 className="size-4 transition-all group-hover:scale-120" />
+              ) : (
+                <Maximize2 className="size-4 transition-all group-hover:scale-120" />
+              )}
+            </Button>
+          </TooltipWrapper>
+        )}
+
+        {/* Close button*/}
+        <TooltipWrapper label="Close (Ctrl+Shift+P)" asChild>
+          <Button variant="ghost" size="sm" onClick={onClose} className="group size-8">
+            <X className="size-4 transition-all group-hover:scale-120" />
+          </Button>
+        </TooltipWrapper>
+      </div>
+    </div>
+  );
+}

--- a/components/floating-theme-editor/floating-theme-editor.tsx
+++ b/components/floating-theme-editor/floating-theme-editor.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { TooltipWrapper } from "@/components/tooltip-wrapper";
+import { Button } from "@/components/ui/button";
+import { DialogActionsProvider } from "@/hooks/use-dialog-actions";
+import { useThemeInspector } from "@/hooks/use-theme-inspector";
+import { cn } from "@/lib/utils";
+import { useEditorStore } from "@/store/editor-store";
+import { ThemeStyles } from "@/types/theme";
+import {
+  DndContext,
+  DragEndEvent,
+  MouseSensor,
+  TouchSensor,
+  useDraggable,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
+import { DropletIcon } from "lucide-react";
+import { useCallback, useEffect } from "react";
+import InspectorOverlay from "../editor/inspector-overlay";
+import ThemeControlPanel from "../editor/theme-control-panel";
+import { FloatingEditorHeader } from "./floating-editor-header";
+import { PanelState, useFloatingEditor, type FloatingEditorOptions } from "./use-floating-editor";
+
+/**
+ * Panel size configurations
+ * - collapsed: Header only (minimal view)
+ * - normal: Default panel with content
+ * - maximized: Full screen mode
+ */
+const PANEL_STYLES = {
+  collapsed: "h-14 w-80",
+  normal: "h-[600px] w-96",
+  maximized: "inset-4 h-auto w-auto",
+} as const;
+
+const DRAGGABLE_ID = "floating-theme-editor";
+
+/**
+ * FloatingThemeEditor Component
+ *
+ * A floating, draggable theme editor that can be minimized, maximized, or closed.
+ * Features:
+ * - Smooth drag and drop positioning with dnd-kit
+ * - Keyboard shortcut (Ctrl+Shift+P) to toggle
+ * - Inspector mode to select and inspect elements
+ * - Real-time theme customization
+ *
+ * @example
+ * ```tsx
+ * <FloatingThemeEditor defaultOpen={false} defaultPosition={{ x: 20, y: 20 }} />
+ * ```
+ */
+export function FloatingThemeEditor(options: FloatingEditorOptions = {}) {
+  const { isOpen, panelState, position, setPosition, toggleOpen, setPanelState } =
+    useFloatingEditor(options);
+
+  const themeState = useEditorStore((state) => state.themeState);
+  const setThemeState = useEditorStore((state) => state.setThemeState);
+
+  const { rootRef, inspector, inspectorEnabled, handleMouseMove, toggleInspector } =
+    useThemeInspector();
+
+  // Configure sensors for smooth dragging
+  const sensors = useSensors(
+    useSensor(MouseSensor, {
+      activationConstraint: {
+        distance: 5,
+      },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 100,
+        tolerance: 5,
+      },
+    })
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { delta } = event;
+      setPosition((prev) => {
+        const panelWidth = 384;
+        const panelHeight = 600;
+        const newX = prev.x + delta.x;
+        const newY = prev.y + delta.y;
+        const offset = 20;
+
+        const minX = offset;
+        const minY = offset;
+        const maxX = window.innerWidth - panelWidth - offset;
+        const maxY = window.innerHeight - panelHeight - offset;
+
+        return {
+          x: Math.max(minX, Math.min(newX, maxX)),
+          y: Math.max(minY, Math.min(newY, maxY)),
+        };
+      });
+    },
+    [setPosition, panelState]
+  );
+
+  const handleStyleChange = useCallback(
+    (newStyles: ThemeStyles) => {
+      const prev = useEditorStore.getState().themeState;
+      setThemeState({ ...prev, styles: newStyles });
+    },
+    [setThemeState]
+  );
+
+  // Set rootRef to document body for global inspection
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      // @ts-expect-error - rootRef expects HTMLDivElement but body is HTMLBodyElement (compatible)
+      rootRef.current = document.body;
+    }
+  }, [rootRef]);
+
+  // Global mouse listener for inspector (inspect entire page except floating editor)
+  useEffect(() => {
+    if (!inspectorEnabled) return;
+
+    const handleGlobalMouseMove = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      if (!target) return;
+
+      // Ignore floating editor and its children
+      if (target.closest("[data-floating-editor]")) return;
+
+      // Ignore inspector overlay itself
+      if (target.closest("[data-inspector-overlay]")) return;
+
+      // Trigger inspection
+      handleMouseMove(event as any);
+    };
+
+    document.addEventListener("mousemove", handleGlobalMouseMove);
+    return () => document.removeEventListener("mousemove", handleGlobalMouseMove);
+  }, [inspectorEnabled, handleMouseMove]);
+
+  // Keep panel within window boundaries on resize
+  useEffect(() => {
+    const handleResize = () => {
+      setPosition((prev) => {
+        const panelWidth = 384;
+        const panelHeight = 600;
+        const offset = 20;
+
+        const minX = offset;
+        const minY = offset;
+        const maxX = window.innerWidth - panelWidth - offset;
+        const maxY = window.innerHeight - panelHeight - offset;
+
+        return {
+          x: Math.max(minX, Math.min(prev.x, maxX)),
+          y: Math.max(minY, Math.min(prev.y, maxY)),
+        };
+      });
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [setPosition, panelState]);
+
+  // Render toggle button when closed
+  if (!isOpen) {
+    return (
+      <TooltipWrapper label="Open Theme Editor (Ctrl+Shift+P)" asChild>
+        <Button
+          onClick={() => toggleOpen(true)}
+          className="fixed right-4 bottom-4 size-12 rounded-full shadow-lg"
+          size="icon"
+          aria-label="Open theme editor (Ctrl+Shift+P)"
+        >
+          <DropletIcon className="scale-125" />
+        </Button>
+      </TooltipWrapper>
+    );
+  }
+
+  const isPanelMaximized = panelState === "maximized";
+  const isPanelCollapsed = panelState === "collapsed";
+
+  return (
+    <>
+      <DndContext sensors={sensors} onDragEnd={handleDragEnd} id={DRAGGABLE_ID}>
+        <DraggablePanel
+          id={DRAGGABLE_ID}
+          position={position}
+          panelState={panelState}
+          disabled={isPanelMaximized}
+        >
+          <FloatingEditorHeader
+            panelState={panelState}
+            inspectorEnabled={inspectorEnabled}
+            onInspectorToggle={toggleInspector}
+            onPanelStateChange={setPanelState}
+            onClose={() => toggleOpen(false)}
+          />
+
+          {/* Show content only when not collapsed */}
+          {!isPanelCollapsed && (
+            <div className="flex min-h-0 flex-1 flex-col overflow-auto">
+              <ThemeControlPanel
+                styles={themeState.styles}
+                onChange={handleStyleChange}
+                currentMode={themeState.currentMode}
+                themePromise={Promise.resolve(null)}
+              />
+            </div>
+          )}
+        </DraggablePanel>
+      </DndContext>
+
+      {/* Inspector overlay for entire page */}
+      <InspectorOverlay inspector={inspector} enabled={inspectorEnabled} rootRef={rootRef} />
+    </>
+  );
+}
+
+interface DraggablePanelProps {
+  id: string;
+  position: { x: number; y: number };
+  panelState: PanelState;
+  disabled: boolean;
+  children: React.ReactNode;
+}
+
+function DraggablePanel({ id, position, panelState, disabled, children }: DraggablePanelProps) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id,
+    disabled,
+  });
+
+  const commonStyles = {
+    zIndex: 50,
+  };
+
+  const style = {
+    ...commonStyles,
+    ...(panelState !== "maximized" && {
+      left: position.x,
+      top: position.y,
+      transform: CSS.Translate.toString(transform),
+    }),
+  };
+
+  return (
+    <DialogActionsProvider>
+      <div
+        ref={setNodeRef}
+        className={cn(
+          "bg-background fixed flex flex-col overflow-hidden rounded-lg border shadow-2xl",
+          PANEL_STYLES[panelState]
+        )}
+        style={style}
+        aria-label="Floating theme editor"
+        data-floating-editor="true"
+        {...attributes}
+        {...listeners}
+      >
+        {children}
+      </div>
+    </DialogActionsProvider>
+  );
+}

--- a/components/floating-theme-editor/index.ts
+++ b/components/floating-theme-editor/index.ts
@@ -1,0 +1,8 @@
+export { FloatingEditorHeader } from "./floating-editor-header";
+export { FloatingThemeEditor } from "./floating-theme-editor";
+export { ThemeEditorProvider } from "./theme-editor-provider";
+export {
+  useFloatingEditor,
+  type FloatingEditorOptions,
+  type PanelState,
+} from "./use-floating-editor";

--- a/components/floating-theme-editor/theme-editor-provider.tsx
+++ b/components/floating-theme-editor/theme-editor-provider.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
+
+// Dynamically import FloatingThemeEditor to avoid hydration issues
+const FloatingThemeEditor = dynamic(
+  () => import("./floating-theme-editor").then((mod) => mod.FloatingThemeEditor),
+  {
+    ssr: false,
+    loading: () => null,
+  }
+);
+
+interface ThemeEditorProviderProps {
+  children: React.ReactNode;
+  /**
+   * Enable the floating theme editor
+   * @default false (only enabled in development)
+   */
+  enabled?: boolean;
+  /**
+   * Show the editor by default
+   * @default false
+   */
+  defaultOpen?: boolean;
+}
+
+/**
+ * Provider component for the floating theme editor.
+ * Automatically injects the theme editor into your Next.js app.
+ *
+ * @example
+ * ```tsx
+ * // In your root layout.tsx
+ * <ThemeEditorProvider>
+ *   {children}
+ * </ThemeEditorProvider>
+ * ```
+ */
+export function ThemeEditorProvider({
+  children,
+  enabled,
+  defaultOpen = false,
+}: ThemeEditorProviderProps) {
+  const [isMounted, setIsMounted] = useState(false);
+
+  // Only show in development by default, but can be overridden
+  const shouldShow = enabled ?? process.env.NODE_ENV === "development";
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  // Prevent hydration mismatch by only rendering on client
+  if (!isMounted || !shouldShow) {
+    return <>{children}</>;
+  }
+
+  return (
+    <>
+      {children}
+      <FloatingThemeEditor defaultOpen={defaultOpen} />
+    </>
+  );
+}

--- a/components/floating-theme-editor/use-floating-editor.tsx
+++ b/components/floating-theme-editor/use-floating-editor.tsx
@@ -1,0 +1,70 @@
+"use client";
+/**
+ * Custom hook for managing floating theme editor state and interactions
+ * Handles panel states, keyboard shortcuts, and position management
+ * Dragging is handled by dnd-kit for smooth performance
+ */
+
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Panel state types
+ * - collapsed: Header only (minimal view)
+ * - normal: Default panel with content
+ * - maximized: Full screen mode
+ */
+export type PanelState = "collapsed" | "normal" | "maximized";
+
+export interface FloatingEditorOptions {
+  defaultOpen?: boolean;
+  defaultPosition?: { x: number; y: number };
+  onToggle?: (isOpen: boolean) => void;
+}
+
+const KEYBOARD_SHORTCUT = {
+  key: "P",
+  ctrl: true,
+  shift: true,
+} as const;
+
+export function useFloatingEditor(options: FloatingEditorOptions = {}) {
+  const { defaultOpen = false, defaultPosition = { x: 20, y: 20 }, onToggle } = options;
+
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  const [panelState, setPanelState] = useState<PanelState>("normal");
+  const [position, setPosition] = useState(defaultPosition);
+
+  // Toggle handler with callback
+  const toggleOpen = useCallback(
+    (value?: boolean) => {
+      setIsOpen((prev) => {
+        const newValue = value ?? !prev;
+        onToggle?.(newValue);
+        return newValue;
+      });
+    },
+    [onToggle]
+  );
+
+  // Keyboard shortcut to toggle editor
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === KEYBOARD_SHORTCUT.key) {
+        e.preventDefault();
+        toggleOpen();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [toggleOpen]);
+
+  return {
+    isOpen,
+    panelState,
+    position,
+    setPosition,
+    toggleOpen,
+    setPanelState,
+  };
+}

--- a/lib/query-client.tsx
+++ b/lib/query-client.tsx
@@ -69,7 +69,7 @@ export function QueryProvider({ children }: QueryProviderProps) {
   return (
     <QueryClientProvider client={queryClient}>
       {children}
-      {process.env.NODE_ENV === "development" && <ReactQueryDevtools initialIsOpen={false} />}
+      {/* {process.env.NODE_ENV === "development" && <ReactQueryDevtools initialIsOpen={false} />} */}
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
This PR adds a Floating Theme Editor - a draggable, DevTools-style panel that lets developers customize themes directly on their actual application pages instead of dummy previews.

## Features
- 🎨 Draggable Panel - Smooth drag & drop with @dnd-kit, stays within window bounds
- 🔍 Inspector Mode - Click any element on the page to inspect and edit its theme classes
- 📐 Three Panel States - Collapsed (header only), Normal (full controls), Maximized (fullscreen)
- ⌨️ Keyboard Shortcut - Ctrl+Shift+P to toggle editor
- 🌍 Global Inspection - Inspect entire page, editor excluded from inspection

📸 Screenshots
Collapsed State:
!collapsed

Normal State with Inspector ON:
!normal

Maximized State:
!maximized

🎯 Demo Workflow
1. Press Ctrl+Shift+P → Editor opens
2. Click Inspector button → Hover over page elements
3. Click element → See theme classes
4. Modify colors → Changes reflect instantly
5. Drag panel anywhere → Smooth movement

below is deployed URL, please take a look:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a floating theme editor panel with drag-to-reposition, panel resize controls (collapse/expand/maximize), and built-in theme inspector.
  * Editor is available in development mode and can be toggled via Ctrl/Cmd + Shift + P keyboard shortcut.

* **Chores**
  * Disabled ReactQueryDevtools rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->