### PR TITLE
fix: update filter behavior to clear tags when 'all' is selected

### DIFF
--- a/app/community/components/community-sidebar.tsx
+++ b/app/community/components/community-sidebar.tsx
@@ -45,7 +45,7 @@ export function CommunitySidebarContent({
           onClick={() => handleFilterClick(item.value)}
           className={cn(
             "flex w-full items-center rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
-            filter === item.value
+            filter === item.value && selectedTags.length === 0
               ? "bg-foreground/10 text-foreground"
               : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground"
           )}

--- a/app/community/components/community-themes-content.tsx
+++ b/app/community/components/community-themes-content.tsx
@@ -97,9 +97,12 @@ export function CommunityThemesContent() {
   const handleFilterChange = useCallback(
     (newFilter: CommunityFilterOption) => {
       setFilter(newFilter);
+      if (newFilter === "all") {
+        setTags([]);
+      }
       setSheetOpen(false);
     },
-    [setFilter]
+    [setFilter, setTags]
   );
 
   const handleTagToggle = useCallback(


### PR DESCRIPTION
## What

- "All Themes" is no longer shown as selected when a tag filter is active
- Clicking "All Themes" now clears the `?tags=` query param from the URL, resetting the page to show all themes

## Why

When a tag was active (e.g., `?tags=minimal`), the sidebar incorrectly highlighted both the tag and "All Themes" simultaneously. Additionally, clicking "All Themes" only updated the `filter` state but left the `tags` param intact, so themes remained filtered.

## Changes

- `app/community/components/community-sidebar.tsx`: Updated active state logic for "All Themes" to only apply when no tags are selected
- `app/community/components/community-themes-content.tsx`: Updated `handleFilterChange` to call `setTags([])` when `"all"` is selected

Closes [#270 ](https://github.com/jnsahaj/tweakcn/issues/270)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter button styling when tags are selected; matching filters now display standard hover states instead of active styling for better visual clarity
  * Fixed the filter reset mechanism; selecting the "all" filter now properly clears any previously selected tags, enabling a cleaner and more intuitive filtering experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->