### PR TITLE
fix(home): resolve double border on testimonial card focus

### DIFF
--- a/components/home/testimonials.tsx
+++ b/components/home/testimonials.tsx
@@ -188,11 +188,11 @@ const MarqueeRow = ({
         {repeatedItems.map((testimonial, i) => (
           <Card
             key={i}
-            className="border-border/40 from-card to-card/50 hover:border-primary/20 group focus-within:ring-primary max-h-[240px] w-full max-w-[420px] min-w-[260px] overflow-hidden border bg-gradient-to-b backdrop-blur transition-all focus-within:ring-2 focus-within:ring-offset-2 hover:shadow-lg sm:max-w-[400px] sm:min-w-[300px]"
+            className="border-border/40 from-card to-card/50 hover:border-primary/20 group focus-within:ring-primary max-h-[240px] w-full max-w-[420px] min-w-[260px] overflow-hidden border bg-gradient-to-b backdrop-blur transition-all focus-within:ring-2 focus-within:ring-offset-2 hover:shadow-lg sm:max-w-[400px] sm:min-w-[300px] py-0"
           >
             <Link
               href={testimonial.href}
-              className="focus:ring-primary h-full rounded-lg focus:ring-2 focus:ring-offset-2 focus:outline-none"
+              className="focus:ring-primary h-full rounded-lg focus:ring-2 focus:ring-offset-2 focus:outline-none py-6"
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
Move vertical padding from Card (py-0) to inner Link (py-6) so the Link fills the Card fully and focus rings don't appear as two separate borders inside Testimonials (home page + pricing)

Steps to reproduce
 - visit https://tweakcn.com/#testimonials
 - click on the `inner` card with the message (or long click and move the cursor away, so you don't get a new tab openned)

(current)
<img width="1726" height="954" alt="Screenshot 2026-04-03 at 15 43 23" src="https://github.com/user-attachments/assets/2ad3d210-4a31-4b64-ad03-eed19dacb0ba" />

(fixed)
<img width="1723" height="889" alt="Screenshot 2026-04-03 at 15 42 17" src="https://github.com/user-attachments/assets/1b630ae0-f63d-46f2-bbe7-1e50c664e5b7" />


PS. `py-6` seem to be applied by JS, it's not a part of the class-names in src, hence the override as a fix on both components
<img width="1719" height="907" alt="Screenshot 2026-04-03 at 16 01 39" src="https://github.com/user-attachments/assets/c4791fbe-60db-4684-8c5e-4af295f7fa77" />


