### PR TITLE
Security: Regular expression injection risk from unsanitized dynamic key

### DIFF
--- a/utils/apply-style-to-element.ts
+++ b/utils/apply-style-to-element.ts
@@ -5,8 +5,9 @@ export function applyStyleToElement(
 ) {
   const currentStyle = element.getAttribute("style") || "";
   // Remove the existing variable definitions with the same name
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const cleanedStyle = currentStyle.replace(
-    new RegExp(`--${key}:\\s*[^;]+;?`, "g"), 
+    new RegExp(`--${escapedKey}:\\s*[^;]+;?`, "g"), 
     ""
   ).trim();
 


### PR DESCRIPTION
## Problem

A dynamic `RegExp` is created from `key` without escaping regex metacharacters. Crafted input can change regex behavior, cause runtime errors, or trigger excessive backtracking in edge cases (ReDoS-style performance impact).

**Severity**: `low`
**File**: `utils/apply-style-to-element.ts`

## Solution

Escape `key` before inserting into `RegExp` (e.g., replace `[.*+?^${}()|[\]\\]`), or avoid regex entirely by using `element.style.removeProperty('--' + key)` with validated keys.

## Changes

- `utils/apply-style-to-element.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
