### PR TITLE
fix(theme): incorrect theme toggle origin

### DIFF
--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -59,8 +59,8 @@ export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
     }
 
     if (coords) {
-      root.style.setProperty("--x", `${coords.x}px`);
-      root.style.setProperty("--y", `${coords.y}px`);
+      root.style.setProperty("--x", `${(coords.x / window.innerWidth) * 100}%`);
+      root.style.setProperty("--y", `${(coords.y / window.innerHeight) * 100}%`);
     }
 
     document.startViewTransition(() => {


### PR DESCRIPTION
Due to an issue in Chrome, the clip path origin was getting incorrectly calculated due to which the origin of the theme toggle had shifted randomly to somewhere near the centre of the header instead of ON the toggle button.

I faced this similar issue in my portfolio, and I had tweeted about it. You can refer to it for more details:
https://x.com/satejbidvai/status/2093387902881562687

This is the fix I did: https://github.com/satejbidvai/portfolio-v3/commit/0ea8c871862f474e9002efb59295ea02cb9c0fb4

### Before
<img width="956" height="313" alt="image" src="https://github.com/user-attachments/assets/a29f0b9d-40b8-4173-8d21-9578998dc06a" />


https://github.com/user-attachments/assets/50fc844b-c15d-4602-8fc4-d02d84b182ec


### After 

<img width="502" height="261" alt="image" src="https://github.com/user-attachments/assets/60029988-fded-44af-bd7e-eee4670d7a62" />


https://github.com/user-attachments/assets/0a2cc5cb-5049-4136-ac11-83fdd3aba915

